### PR TITLE
Cover the ffmpeg 4.1 enums

### DIFF
--- a/src/codec/id.rs
+++ b/src/codec/id.rs
@@ -490,6 +490,26 @@ pub enum Id {
     APTX_HD,
     #[cfg(feature = "ffmpeg4")]
     SBC,
+    #[cfg(feature = "ffmpeg4")]
+    AVS2,
+    #[cfg(feature = "ffmpeg4")]
+    IMM4,
+    #[cfg(feature = "ffmpeg4")]
+    Prosumer,
+    #[cfg(feature = "ffmpeg4")]
+    MWSC,
+    #[cfg(feature = "ffmpeg4")]
+    WCMV,
+    #[cfg(feature = "ffmpeg4")]
+    RASC,
+    #[cfg(feature = "ffmpeg4")]
+    FirstAudio,
+    #[cfg(feature = "ffmpeg4")]
+    PCM_VIDC,
+    #[cfg(feature = "ffmpeg4")]
+    ATRAC9,
+    #[cfg(feature = "ffmpeg4")]
+    TTML,
 }
 
 impl Id {
@@ -982,6 +1002,26 @@ impl From<AVCodecID> for Id {
             AV_CODEC_ID_APTX_HD => Id::APTX_HD,
             #[cfg(feature = "ffmpeg4")]
             AV_CODEC_ID_SBC => Id::SBC,
+            #[cfg(feature = "ffmpeg4")]
+            AV_CODEC_ID_AVS2 => Id::AVS2,
+            #[cfg(feature = "ffmpeg4")]
+            AV_CODEC_ID_IMM4 => Id::IMM4,
+            #[cfg(feature = "ffmpeg4")]
+            AV_CODEC_ID_PROSUMER => Id::Prosumer,
+            #[cfg(feature = "ffmpeg4")]
+            AV_CODEC_ID_MWSC => Id::MWSC,
+            #[cfg(feature = "ffmpeg4")]
+            AV_CODEC_ID_WCMV => Id::WCMV,
+            #[cfg(feature = "ffmpeg4")]
+            AV_CODEC_ID_RASC => Id::RASC,
+            #[cfg(feature = "ffmpeg4")]
+            AV_CODEC_ID_FIRST_AUDIO => Id::FirstAudio,
+            #[cfg(feature = "ffmpeg4")]
+            AV_CODEC_ID_PCM_VIDC => Id::PCM_VIDC,
+            #[cfg(feature = "ffmpeg4")]
+            AV_CODEC_ID_ATRAC9 => Id::ATRAC9,
+            #[cfg(feature = "ffmpeg4")]
+            AV_CODEC_ID_TTML => Id::TTML,
         }
     }
 }
@@ -1471,6 +1511,26 @@ impl Into<AVCodecID> for Id {
             Id::APTX_HD => AV_CODEC_ID_APTX_HD,
             #[cfg(feature = "ffmpeg4")]
             Id::SBC => AV_CODEC_ID_SBC,
+            #[cfg(feature = "ffmpeg4")]
+            Id::AVS2 => AV_CODEC_ID_AVS2,
+            #[cfg(feature = "ffmpeg4")]
+            Id::IMM4 => AV_CODEC_ID_IMM4,
+            #[cfg(feature = "ffmpeg4")]
+            Id::Prosumer => AV_CODEC_ID_PROSUMER,
+            #[cfg(feature = "ffmpeg4")]
+            Id::MWSC => AV_CODEC_ID_MWSC,
+            #[cfg(feature = "ffmpeg4")]
+            Id::WCMV => AV_CODEC_ID_WCMV,
+            #[cfg(feature = "ffmpeg4")]
+            Id::RASC => AV_CODEC_ID_RASC,
+            #[cfg(feature = "ffmpeg4")]
+            Id::FirstAudio => AV_CODEC_ID_FIRST_AUDIO,
+            #[cfg(feature = "ffmpeg4")]
+            Id::PCM_VIDC => AV_CODEC_ID_PCM_VIDC,
+            #[cfg(feature = "ffmpeg4")]
+            Id::ATRAC9 => AV_CODEC_ID_ATRAC9,
+            #[cfg(feature = "ffmpeg4")]
+            Id::TTML => AV_CODEC_ID_TTML,
         }
     }
 }

--- a/src/codec/packet/side_data.rs
+++ b/src/codec/packet/side_data.rs
@@ -37,6 +37,8 @@ pub enum Type {
     EncryptionInitInfo,
     #[cfg(feature = "ffmpeg4")]
     EncryptionInfo,
+    #[cfg(feature = "ffmpeg4")]
+    AFD,
 }
 
 impl From<AVPacketSideDataType> for Type {
@@ -72,6 +74,8 @@ impl From<AVPacketSideDataType> for Type {
             AV_PKT_DATA_ENCRYPTION_INIT_INFO => Type::EncryptionInitInfo,
             #[cfg(feature = "ffmpeg4")]
             AV_PKT_DATA_ENCRYPTION_INFO => Type::EncryptionInfo,
+            #[cfg(feature = "ffmpeg4")]
+            AV_PKT_DATA_AFD => Type::AFD,
         }
     }
 }
@@ -109,6 +113,8 @@ impl Into<AVPacketSideDataType> for Type {
             Type::EncryptionInitInfo => AV_PKT_DATA_ENCRYPTION_INIT_INFO,
             #[cfg(feature = "ffmpeg4")]
             Type::EncryptionInfo => AV_PKT_DATA_ENCRYPTION_INFO,
+            #[cfg(feature = "ffmpeg4")]
+            Type::AFD => AV_PKT_DATA_AFD,
         }
     }
 }

--- a/src/util/format/pixel.rs
+++ b/src/util/format/pixel.rs
@@ -313,6 +313,14 @@ pub enum Pixel {
     DRM_PRIME,
     #[cfg(feature = "ffmpeg4")]
     OPENCL,
+    #[cfg(feature = "ffmpeg4")]
+    GRAY14BE,
+    #[cfg(feature = "ffmpeg4")]
+    GRAY14LE,
+    #[cfg(feature = "ffmpeg4")]
+    GRAYF32BE,
+    #[cfg(feature = "ffmpeg4")]
+    GRAYF32LE,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -597,6 +605,14 @@ impl From<AVPixelFormat> for Pixel {
             AV_PIX_FMT_DRM_PRIME => Pixel::DRM_PRIME,
             #[cfg(feature = "ffmpeg4")]
             AV_PIX_FMT_OPENCL => Pixel::OPENCL,
+            #[cfg(feature = "ffmpeg4")]
+            AV_PIX_FMT_GRAY14BE => Pixel::GRAY14BE,
+            #[cfg(feature = "ffmpeg4")]
+            AV_PIX_FMT_GRAY14LE => Pixel::GRAY14LE,
+            #[cfg(feature = "ffmpeg4")]
+            AV_PIX_FMT_GRAYF32BE => Pixel::GRAYF32BE,
+            #[cfg(feature = "ffmpeg4")]
+            AV_PIX_FMT_GRAYF32LE => Pixel::GRAYF32LE,
         }
     }
 }
@@ -910,6 +926,14 @@ impl Into<AVPixelFormat> for Pixel {
             Pixel::DRM_PRIME => AV_PIX_FMT_DRM_PRIME,
             #[cfg(feature = "ffmpeg4")]
             Pixel::OPENCL => AV_PIX_FMT_OPENCL,
+            #[cfg(feature = "ffmpeg4")]
+            Pixel::GRAY14BE  => AV_PIX_FMT_GRAY14BE,
+            #[cfg(feature = "ffmpeg4")]
+            Pixel::GRAY14LE  => AV_PIX_FMT_GRAY14LE,
+            #[cfg(feature = "ffmpeg4")]
+            Pixel::GRAYF32BE  => AV_PIX_FMT_GRAYF32BE,
+            #[cfg(feature = "ffmpeg4")]
+            Pixel::GRAYF32LE  => AV_PIX_FMT_GRAYF32LE,
         }
     }
 }

--- a/src/util/frame/side_data.rs
+++ b/src/util/frame/side_data.rs
@@ -32,6 +32,8 @@ pub enum Type {
     QPTableProperties,
     #[cfg(feature = "ffmpeg4")]
     QPTableData,
+    #[cfg(feature = "ffmpeg4")]
+    S12MTimecode,
 }
 
 impl Type {
@@ -69,6 +71,8 @@ impl From<AVFrameSideDataType> for Type {
             AV_FRAME_DATA_QP_TABLE_PROPERTIES => Type::QPTableProperties,
             #[cfg(feature = "ffmpeg4")]
             AV_FRAME_DATA_QP_TABLE_DATA => Type::QPTableData,
+            #[cfg(feature = "ffmpeg4")]
+            AV_FRAME_DATA_S12M_TIMECODE => Type::S12MTimecode,
         }
     }
 }
@@ -99,6 +103,8 @@ impl Into<AVFrameSideDataType> for Type {
             Type::QPTableProperties => AV_FRAME_DATA_QP_TABLE_PROPERTIES,
             #[cfg(feature = "ffmpeg4")]
             Type::QPTableData => AV_FRAME_DATA_QP_TABLE_DATA,
+            #[cfg(feature = "ffmpeg4")]
+            Type::S12MTimecode => AV_FRAME_DATA_S12M_TIMECODE,
         }
     }
 }


### PR DESCRIPTION
This will make the crate compile against ffmpeg 4.1 (tested against 4.1.3). It just does the minimal change to make the crate compile, which is to extend the enums to cover the new variants.