### PR TITLE
Add example programs to cargo for ease of building/running

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,3 +107,23 @@ optional = true
 path = "../rust-ffmpeg-sys"
 version = "4.3"
 default-features = false
+
+[[bin]]
+name = "avi-to-ppm"
+path = "examples/avi-to-ppm.rs"
+
+[[bin]]
+name = "chapters"
+path = "examples/chapters.rs"
+
+[[bin]]
+name = "codec-info"
+path = "examples/codec-info.rs"
+
+[[bin]]
+name = "metadata"
+path = "examples/metadata.rs"
+
+[[bin]]
+name = "transcode-audio"
+path = "examples/transcode-audio.rs"


### PR DESCRIPTION
This is quite a simple PR, but makes it a bit easier for newcomers to quickly try out the examples in this project. After this change, it's possible to simply run (for example): 
    
    cargo run --bin transcode-audio <input.mp3> <output.wav> 
    