### PR TITLE
Misc fixes

### DIFF
--- a/src/codec/packet/packet.rs
+++ b/src/codec/packet/packet.rs
@@ -127,9 +127,7 @@ impl Packet {
 
     #[inline]
     pub fn set_pts(&mut self, value: Option<i64>) {
-        unsafe {
-            (*self.as_mut_ptr()).pts = value.unwrap_or(AV_NOPTS_VALUE);
-        }
+        self.0.pts = value.unwrap_or(AV_NOPTS_VALUE);
     }
 
     #[inline]
@@ -142,9 +140,7 @@ impl Packet {
 
     #[inline]
     pub fn set_dts(&mut self, value: Option<i64>) {
-        unsafe {
-            (*self.as_mut_ptr()).dts = value.unwrap_or(AV_NOPTS_VALUE);
-        }
+        self.0.dts = value.unwrap_or(AV_NOPTS_VALUE);
     }
 
     #[inline]
@@ -158,8 +154,18 @@ impl Packet {
     }
 
     #[inline]
+    pub fn set_duration(&mut self, value: i64) {
+        self.0.duration = value;
+    }
+
+    #[inline]
     pub fn position(&self) -> isize {
         self.0.pos as isize
+    }
+
+    #[inline]
+    pub fn set_position(&mut self, value: isize) {
+        self.0.pos = value as i64
     }
 
     #[inline]

--- a/src/codec/picture.rs
+++ b/src/codec/picture.rs
@@ -58,9 +58,9 @@ impl<'a> Picture<'a> {
 
     pub fn new(format: format::Pixel, width: u32, height: u32) -> Result<Self, Error> {
         unsafe {
-            let ptr = av_malloc(mem::size_of::<AVPicture>() as size_t) as *mut AVPicture;
+            let ptr = av_malloc(mem::size_of::<AVPicture>() as _) as *mut AVPicture;
 
-            match avpicture_alloc(ptr, format.into(), width as c_int, height as c_int) {
+            match avpicture_alloc(ptr, format.into(), width as _, height as _) {
                 0 => Ok(Picture {
                     ptr,
 

--- a/src/codec/subtitle/mod.rs
+++ b/src/codec/subtitle/mod.rs
@@ -101,11 +101,11 @@ impl Subtitle {
             self.0.num_rects += 1;
             self.0.rects = av_realloc(
                 self.0.rects as *mut _,
-                (mem::size_of::<*const AVSubtitleRect>() * self.0.num_rects as usize) as size_t,
+                (mem::size_of::<*const AVSubtitleRect>() * self.0.num_rects as usize) as _,
             ) as *mut _;
 
             let rect =
-                av_mallocz(mem::size_of::<AVSubtitleRect>() as size_t) as *mut AVSubtitleRect;
+                av_mallocz(mem::size_of::<AVSubtitleRect>() as _) as *mut AVSubtitleRect;
             (*rect).type_ = kind.into();
 
             *self.0.rects.offset((self.0.num_rects - 1) as isize) = rect;

--- a/src/format/context/output.rs
+++ b/src/format/context/output.rs
@@ -72,8 +72,9 @@ impl Output {
 
     pub fn add_stream<E: traits::Encoder>(&mut self, codec: E) -> Result<StreamMut, Error> {
         unsafe {
-            let codec = codec.encoder().ok_or(Error::EncoderNotFound)?;
-            let ptr = avformat_new_stream(self.as_mut_ptr(), codec.as_ptr());
+            let codec = codec.encoder();
+            let codec = codec.map_or(ptr::null(), |c| c.as_ptr());
+            let ptr = avformat_new_stream(self.as_mut_ptr(), codec);
 
             if ptr.is_null() {
                 panic!("out of memory");

--- a/src/format/context/output.rs
+++ b/src/format/context/output.rs
@@ -111,7 +111,7 @@ impl Output {
         let index = match existing {
             Some(index) => index,
             None => unsafe {
-                let ptr = av_mallocz(size_of::<AVChapter>())
+                let ptr = av_mallocz(size_of::<AVChapter>() as _)
                     .as_mut()
                     .ok_or(Error::Bug)?;
                 let mut nb_chapters = (*self.as_ptr()).nb_chapters as i32;

--- a/src/format/context/output.rs
+++ b/src/format/context/output.rs
@@ -77,7 +77,7 @@ impl Output {
             let ptr = avformat_new_stream(self.as_mut_ptr(), codec);
 
             if ptr.is_null() {
-                panic!("out of memory");
+                return Err(Error::Unknown);
             }
 
             let index = (*self.ctx.as_ptr()).nb_streams - 1;

--- a/src/software/resampling/context.rs
+++ b/src/software/resampling/context.rs
@@ -20,6 +20,8 @@ pub struct Context {
     output: Definition,
 }
 
+unsafe impl Send for Context {}
+
 impl Context {
     #[doc(hidden)]
     pub unsafe fn as_ptr(&self) -> *const SwrContext {

--- a/src/util/dictionary/immutable.rs
+++ b/src/util/dictionary/immutable.rs
@@ -1,5 +1,6 @@
 use std::ffi::{CStr, CString};
 use std::marker::PhantomData;
+use std::fmt;
 use std::ptr;
 use std::str::from_utf8_unchecked;
 
@@ -56,5 +57,11 @@ impl<'a> IntoIterator for &'a Ref<'a> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
+    }
+}
+
+impl<'a> fmt::Debug for Ref<'a> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_map().entries(self.iter()).finish()
     }
 }

--- a/src/util/dictionary/mutable.rs
+++ b/src/util/dictionary/mutable.rs
@@ -1,7 +1,7 @@
 use std::ffi::CString;
 use std::marker::PhantomData;
 use std::ops::Deref;
-
+use std::fmt;
 use super::immutable;
 use ffi::*;
 
@@ -48,5 +48,11 @@ impl<'a> Deref for Ref<'a> {
 
     fn deref(&self) -> &Self::Target {
         &self.imm
+    }
+}
+
+impl<'a> fmt::Debug for Ref<'a> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        self.imm.fmt(fmt)
     }
 }

--- a/src/util/dictionary/owned.rs
+++ b/src/util/dictionary/owned.rs
@@ -1,7 +1,7 @@
 use std::iter::FromIterator;
 use std::ops::{Deref, DerefMut};
 use std::ptr;
-
+use std::fmt;
 use super::mutable;
 use ffi::*;
 
@@ -124,5 +124,11 @@ impl<'a> Drop for Owned<'a> {
         unsafe {
             av_dict_free(&mut self.inner.as_mut_ptr());
         }
+    }
+}
+
+impl<'a> fmt::Debug for Owned<'a> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        self.inner.fmt(fmt)
     }
 }

--- a/src/util/error.rs
+++ b/src/util/error.rs
@@ -178,140 +178,140 @@ pub fn register_all() {
         av_strerror(
             Error::Bug.into(),
             STRINGS[index(&Error::Bug)].as_mut_ptr(),
-            AV_ERROR_MAX_STRING_SIZE,
+            AV_ERROR_MAX_STRING_SIZE as _,
         );
         av_strerror(
             Error::Bug2.into(),
             STRINGS[index(&Error::Bug2)].as_mut_ptr(),
-            AV_ERROR_MAX_STRING_SIZE,
+            AV_ERROR_MAX_STRING_SIZE as _,
         );
         av_strerror(
             Error::Unknown.into(),
             STRINGS[index(&Error::Unknown)].as_mut_ptr(),
-            AV_ERROR_MAX_STRING_SIZE,
+            AV_ERROR_MAX_STRING_SIZE as _,
         );
         av_strerror(
             Error::Experimental.into(),
             STRINGS[index(&Error::Experimental)].as_mut_ptr(),
-            AV_ERROR_MAX_STRING_SIZE,
+            AV_ERROR_MAX_STRING_SIZE as _,
         );
         av_strerror(
             Error::BufferTooSmall.into(),
             STRINGS[index(&Error::BufferTooSmall)].as_mut_ptr(),
-            AV_ERROR_MAX_STRING_SIZE,
+            AV_ERROR_MAX_STRING_SIZE as _,
         );
         av_strerror(
             Error::Eof.into(),
             STRINGS[index(&Error::Eof)].as_mut_ptr(),
-            AV_ERROR_MAX_STRING_SIZE,
+            AV_ERROR_MAX_STRING_SIZE as _,
         );
         av_strerror(
             Error::Exit.into(),
             STRINGS[index(&Error::Exit)].as_mut_ptr(),
-            AV_ERROR_MAX_STRING_SIZE,
+            AV_ERROR_MAX_STRING_SIZE as _,
         );
         av_strerror(
             Error::External.into(),
             STRINGS[index(&Error::External)].as_mut_ptr(),
-            AV_ERROR_MAX_STRING_SIZE,
+            AV_ERROR_MAX_STRING_SIZE as _,
         );
         av_strerror(
             Error::InvalidData.into(),
             STRINGS[index(&Error::InvalidData)].as_mut_ptr(),
-            AV_ERROR_MAX_STRING_SIZE,
+            AV_ERROR_MAX_STRING_SIZE as _,
         );
         av_strerror(
             Error::PatchWelcome.into(),
             STRINGS[index(&Error::PatchWelcome)].as_mut_ptr(),
-            AV_ERROR_MAX_STRING_SIZE,
+            AV_ERROR_MAX_STRING_SIZE as _,
         );
 
         av_strerror(
             Error::InputChanged.into(),
             STRINGS[index(&Error::InputChanged)].as_mut_ptr(),
-            AV_ERROR_MAX_STRING_SIZE,
+            AV_ERROR_MAX_STRING_SIZE as _,
         );
         av_strerror(
             Error::OutputChanged.into(),
             STRINGS[index(&Error::OutputChanged)].as_mut_ptr(),
-            AV_ERROR_MAX_STRING_SIZE,
+            AV_ERROR_MAX_STRING_SIZE as _,
         );
 
         av_strerror(
             Error::BsfNotFound.into(),
             STRINGS[index(&Error::BsfNotFound)].as_mut_ptr(),
-            AV_ERROR_MAX_STRING_SIZE,
+            AV_ERROR_MAX_STRING_SIZE as _,
         );
         av_strerror(
             Error::DecoderNotFound.into(),
             STRINGS[index(&Error::DecoderNotFound)].as_mut_ptr(),
-            AV_ERROR_MAX_STRING_SIZE,
+            AV_ERROR_MAX_STRING_SIZE as _,
         );
         av_strerror(
             Error::DemuxerNotFound.into(),
             STRINGS[index(&Error::DemuxerNotFound)].as_mut_ptr(),
-            AV_ERROR_MAX_STRING_SIZE,
+            AV_ERROR_MAX_STRING_SIZE as _,
         );
         av_strerror(
             Error::EncoderNotFound.into(),
             STRINGS[index(&Error::EncoderNotFound)].as_mut_ptr(),
-            AV_ERROR_MAX_STRING_SIZE,
+            AV_ERROR_MAX_STRING_SIZE as _,
         );
         av_strerror(
             Error::OptionNotFound.into(),
             STRINGS[index(&Error::OptionNotFound)].as_mut_ptr(),
-            AV_ERROR_MAX_STRING_SIZE,
+            AV_ERROR_MAX_STRING_SIZE as _,
         );
         av_strerror(
             Error::MuxerNotFound.into(),
             STRINGS[index(&Error::MuxerNotFound)].as_mut_ptr(),
-            AV_ERROR_MAX_STRING_SIZE,
+            AV_ERROR_MAX_STRING_SIZE as _,
         );
         av_strerror(
             Error::FilterNotFound.into(),
             STRINGS[index(&Error::FilterNotFound)].as_mut_ptr(),
-            AV_ERROR_MAX_STRING_SIZE,
+            AV_ERROR_MAX_STRING_SIZE as _,
         );
         av_strerror(
             Error::ProtocolNotFound.into(),
             STRINGS[index(&Error::ProtocolNotFound)].as_mut_ptr(),
-            AV_ERROR_MAX_STRING_SIZE,
+            AV_ERROR_MAX_STRING_SIZE as _,
         );
         av_strerror(
             Error::StreamNotFound.into(),
             STRINGS[index(&Error::StreamNotFound)].as_mut_ptr(),
-            AV_ERROR_MAX_STRING_SIZE,
+            AV_ERROR_MAX_STRING_SIZE as _,
         );
 
         av_strerror(
             Error::HttpBadRequest.into(),
             STRINGS[index(&Error::HttpBadRequest)].as_mut_ptr(),
-            AV_ERROR_MAX_STRING_SIZE,
+            AV_ERROR_MAX_STRING_SIZE as _,
         );
         av_strerror(
             Error::HttpUnauthorized.into(),
             STRINGS[index(&Error::HttpUnauthorized)].as_mut_ptr(),
-            AV_ERROR_MAX_STRING_SIZE,
+            AV_ERROR_MAX_STRING_SIZE as _,
         );
         av_strerror(
             Error::HttpForbidden.into(),
             STRINGS[index(&Error::HttpForbidden)].as_mut_ptr(),
-            AV_ERROR_MAX_STRING_SIZE,
+            AV_ERROR_MAX_STRING_SIZE as _,
         );
         av_strerror(
             Error::HttpNotFound.into(),
             STRINGS[index(&Error::HttpNotFound)].as_mut_ptr(),
-            AV_ERROR_MAX_STRING_SIZE,
+            AV_ERROR_MAX_STRING_SIZE as _,
         );
         av_strerror(
             Error::HttpOther4xx.into(),
             STRINGS[index(&Error::HttpOther4xx)].as_mut_ptr(),
-            AV_ERROR_MAX_STRING_SIZE,
+            AV_ERROR_MAX_STRING_SIZE as _,
         );
         av_strerror(
             Error::HttpServerError.into(),
             STRINGS[index(&Error::HttpServerError)].as_mut_ptr(),
-            AV_ERROR_MAX_STRING_SIZE,
+            AV_ERROR_MAX_STRING_SIZE as _,
         );
     }
 }


### PR DESCRIPTION
The `as _` code allows it to work when cross-compiled for ARM, which happens to pick slightly different types.