### PR TITLE
Small fix to transcode-x264.rs

### DIFF
--- a/examples/transcode-x264.rs
+++ b/examples/transcode-x264.rs
@@ -246,6 +246,7 @@ fn main() {
                 // Do stream copy on non-video streams.
                 packet.rescale_ts(ist_time_bases[ist_index], ost_time_base);
                 packet.set_position(-1);
+                packet.set_stream(ost_index as _);
                 packet.write_interleaved(&mut octx).unwrap();
             }
         }


### PR DESCRIPTION
This example doesn't encode stream types other than video, audio and subtitles. It just skips these streams. That means that the number of the output streams isn't necessarily the same as the number of input streams. Most parts of the example handle that well, except for this part which redirects all non-video input streams to an output stream with the same index, which cause an error for me. This change fixes it.

Congrats on the windows and mac pipelines by the way! Thank you!