### PR TITLE
fix bug with null ptr

### DIFF
--- a/examples/codec-info.rs
+++ b/examples/codec-info.rs
@@ -10,7 +10,10 @@ fn main() {
             println!("type: decoder");
             println!("\t id: {:?}", codec.id());
             println!("\t name: {}", codec.name());
-            println!("\t description: {}", codec.description());
+            println!(
+                "\t description: {}",
+                codec.description().unwrap_or("Unknown")
+            );
             println!("\t medium: {:?}", codec.medium());
             println!("\t capabilities: {:?}", codec.capabilities());
 
@@ -62,7 +65,10 @@ fn main() {
             println!("type: encoder");
             println!("\t id: {:?}", codec.id());
             println!("\t name: {}", codec.name());
-            println!("\t description: {}", codec.description());
+            println!(
+                "\t description: {}",
+                codec.description().unwrap_or("Unknown")
+            );
             println!("\t medium: {:?}", codec.medium());
             println!("\t capabilities: {:?}", codec.capabilities());
 

--- a/src/codec/codec.rs
+++ b/src/codec/codec.rs
@@ -40,8 +40,17 @@ impl Codec {
         unsafe { from_utf8_unchecked(CStr::from_ptr((*self.as_ptr()).name).to_bytes()) }
     }
 
-    pub fn description(&self) -> &str {
-        unsafe { from_utf8_unchecked(CStr::from_ptr((*self.as_ptr()).long_name).to_bytes()) }
+    pub fn description(&self) -> Option<&str> {
+        unsafe {
+            let long_name = (*self.as_ptr()).long_name;
+            if !long_name.is_null() {
+                let long_name =
+                    from_utf8_unchecked(CStr::from_ptr((*self.as_ptr()).long_name).to_bytes());
+                Some(long_name)
+            } else {
+                None
+            }
+        }
     }
 
     pub fn medium(&self) -> media::Type {


### PR DESCRIPTION
From the documentation: 
const char* AVCodec::long_name
Descriptive name for the codec, meant to be more human readable than name.
You should use the NULL_IF_CONFIG_SMALL() macro to define it.
Where: 
#if CONFIG_SMALL
#define NULL_IF_CONFIG_SMALL(x) NULL
#else
#define NULL_IF_CONFIG_SMALL(x) x
#endif


Also, in some codecs this field is not initialized and will remain zero. For instance: https://ffmpeg.org/doxygen/4.1/libwavpackenc_8c_source.html

 AVCodec ff_libwavpack_encoder = {
      .name           = "libwavpack",
      .type           = AVMEDIA_TYPE_AUDIO,
     .id             = AV_CODEC_ID_WAVPACK,
     .priv_data_size = sizeof(LibWavpackContext),
     .init           = wavpack_encode_init,
     .encode2        = wavpack_encode_frame,
     .close          = wavpack_encode_close,
     .capabilities   = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_SMALL_LAST_FRAME,
     .sample_fmts    = (const enum AVSampleFormat[]){ AV_SAMPLE_FMT_S32,
                                                      AV_SAMPLE_FMT_NONE },
      .wrapper_name   = "libwavpack",
  };

You can check on an existing example by the following run:
cargo run --example codec-info libwavpack