### PR TITLE
codec: fix codec description potential null ptr issue

### DIFF
--- a/src/codec/codec.rs
+++ b/src/codec/codec.rs
@@ -41,7 +41,14 @@ impl Codec {
     }
 
     pub fn description(&self) -> &str {
-        unsafe { from_utf8_unchecked(CStr::from_ptr((*self.as_ptr()).long_name).to_bytes()) }
+        unsafe {
+            let long_name = (*self.as_ptr()).long_name;
+            if long_name.is_null() {
+                ""
+            } else {
+                from_utf8_unchecked(CStr::from_ptr(long_name).to_bytes())
+            }
+        }
     }
 
     pub fn medium(&self) -> media::Type {


### PR DESCRIPTION
Codecs may not have `.long_name` initialized.

Issue raised by @Pilyushkin in #34.