### PR TITLE
Create resampler with dictionary of options

### DIFF
--- a/src/software/resampling/context.rs
+++ b/src/software/resampling/context.rs
@@ -3,10 +3,10 @@ use std::ptr;
 use super::Delay;
 use ffi::*;
 use libc::c_int;
-use util::format;
-use {frame, ChannelLayout, Error};
-use Dictionary;
 use std::ffi::c_void;
+use util::format;
+use Dictionary;
+use {frame, ChannelLayout, Error};
 
 #[derive(Eq, PartialEq, Copy, Clone)]
 pub struct Definition {
@@ -46,7 +46,15 @@ impl Context {
         dst_channel_layout: ChannelLayout,
         dst_rate: u32,
     ) -> Result<Self, Error> {
-        Self::get_with(src_format, src_channel_layout, src_rate, dst_format, dst_channel_layout, dst_rate, Dictionary::new())
+        Self::get_with(
+            src_format,
+            src_channel_layout,
+            src_rate,
+            dst_format,
+            dst_channel_layout,
+            dst_rate,
+            Dictionary::new(),
+        )
     }
 
     /// Create a resampler with the given definitions and custom options dictionary.


### PR DESCRIPTION
The libswresample resampler can be created with a dictionary of options. This pull request adds it to the rust-ffmpeg Context API with a new function `Context::get_with` modelled after `Audio::open_with`.

```rust
Context::get_with(
    sample_format_fltp(),
    ChannelLayout::MONO,
    source_sample_rate as u32,
    sample_format_fltp(),
    ChannelLayout::MONO,
    dest_sample_rate as u32,
    [("resampler", "soxr"), ("precision", "32")]
        .iter()
        .collect(),
)
```