### PR TITLE
Implemented Buffer destructor mode

### DIFF
--- a/src/format/context/destructor.rs
+++ b/src/format/context/destructor.rs
@@ -4,6 +4,7 @@ use ffi::*;
 pub enum Mode {
     Input,
     Output,
+    Buffer,
 }
 
 pub struct Destructor {
@@ -25,6 +26,10 @@ impl Drop for Destructor {
 
                 Mode::Output => {
                     avio_close((*self.ptr).pb);
+                    avformat_free_context(self.ptr);
+                }
+
+                Mode::Buffer => {
                     avformat_free_context(self.ptr);
                 }
             }

--- a/src/format/context/input.rs
+++ b/src/format/context/input.rs
@@ -23,6 +23,13 @@ impl Input {
         }
     }
 
+    pub unsafe fn wrap_buffer(ptr: *mut AVFormatContext) -> Self {
+        Input {
+            ptr,
+            ctx: Context::wrap(ptr, destructor::Mode::Buffer),
+        }
+    }
+
     pub unsafe fn as_ptr(&self) -> *const AVFormatContext {
         self.ptr as *const _
     }

--- a/src/format/context/output.rs
+++ b/src/format/context/output.rs
@@ -26,6 +26,13 @@ impl Output {
         }
     }
 
+    pub unsafe fn wrap_buffer(ptr: *mut AVFormatContext) -> Self {
+        Output {
+            ptr,
+            ctx: Context::wrap(ptr, destructor::Mode::Buffer),
+        }
+    }
+
     pub unsafe fn as_ptr(&self) -> *const AVFormatContext {
         self.ptr as *const _
     }


### PR DESCRIPTION
Hi :)

I use your library in order to decode jpegs from a `Vec` to a video, also as a `Vec`.
In order to do so I use the "wrap" function of the output context on an `AVFromatContext` I create myself.
The problem is, the `Output` destructor mode assumes it opened a file (which I have not) and performs `avio_close` on the `ptr`, which causes a double free.

Therefore, I added a third destructor mode "Buffer" that only preforms avformat_free_context. I myself am not sure about the name "Buffer", but it's better than "NotFile" so I'm open for suggestoins.

Also, If you would like, I can open a follow-up PR that adds my implementation of the in-memory context.

Thank you and waiting to here from you soon :)