### PR TITLE
codec: add new_with_codec method to codec context

### DIFF
--- a/src/codec/context.rs
+++ b/src/codec/context.rs
@@ -40,6 +40,15 @@ impl Context {
         }
     }
 
+    pub fn new_with_codec(codec: Codec) -> Self {
+        unsafe {
+            Context {
+                ptr: avcodec_alloc_context3(codec.as_ptr()),
+                owner: None,
+            }
+        }
+    }
+
     pub fn decoder(self) -> Decoder {
         Decoder(self)
     }


### PR DESCRIPTION
Wrapper for "avcodec_alloc_context3" with not-null codec is needed when you dont use output stream, so you cant pass a codec to "add_stream" method