### PR TITLE
Add two open_with implementations

### DIFF
--- a/src/codec/decoder/decoder.rs
+++ b/src/codec/decoder/decoder.rs
@@ -31,6 +31,20 @@ impl Decoder {
         }
     }
 
+    pub fn open_with(mut self, options: Dictionary) -> Result<Opened, Error> {
+        unsafe {
+            let mut opts = options.disown();
+            let res = avcodec_open2(self.as_mut_ptr(), ptr::null(), &mut opts);
+
+            Dictionary::own(opts);
+
+            match res {
+                0 => Ok(Opened(self)),
+                e => Err(Error::from(e)),
+            }
+        }
+    }
+
     pub fn open_as_with<D: traits::Decoder>(
         mut self,
         codec: D,

--- a/src/codec/encoder/subtitle.rs
+++ b/src/codec/encoder/subtitle.rs
@@ -33,6 +33,20 @@ impl Subtitle {
         }
     }
 
+    pub fn open_with(mut self, options: Dictionary) -> Result<Encoder, Error> {
+        unsafe {
+            let mut opts = options.disown();
+            let res = avcodec_open2(self.as_mut_ptr(), ptr::null(), &mut opts);
+
+            Dictionary::own(opts);
+
+            match res {
+                0 => Ok(Encoder(self)),
+                e => Err(Error::from(e)),
+            }
+        }
+    }
+
     pub fn open_as_with<E: traits::Encoder>(
         mut self,
         codec: E,


### PR DESCRIPTION
I found myself wanting to use `open_with` on a decoder before knowing what the codec being decoded is (making `open_as_with` infeasible). This PR adds that implementation and also for `encoder/subtitle.rs` as that's the only encoder it's missing for.

I checked the ffmpeg docs and didn't see a reason why this usage would be invalid which would lead them to be left out but that is the case sorry for taking up your time.