### PR TITLE
Add unimplemented for a few matches

### DIFF
--- a/src/codec/id.rs
+++ b/src/codec/id.rs
@@ -1139,6 +1139,8 @@ impl From<AVCodecID> for Id {
             AV_CODEC_ID_HCA => Id::HCA,
             #[cfg(feature = "ffmpeg_4_3")]
             AV_CODEC_ID_EPG => Id::EPG,
+            #[allow(unreachable_pattern)]
+            _ => unimplemented!(),
         }
     }
 }
@@ -1704,6 +1706,8 @@ impl Into<AVCodecID> for Id {
             Id::HCA => AV_CODEC_ID_HCA,
             #[cfg(feature = "ffmpeg_4_3")]
             Id::EPG => AV_CODEC_ID_EPG,
+            #[allow(unreachable_patterns)]
+            _ => unimplemented!(),
         }
     }
 }

--- a/src/codec/packet/side_data.rs
+++ b/src/codec/packet/side_data.rs
@@ -94,6 +94,8 @@ impl From<AVPacketSideDataType> for Type {
             AV_PKT_DATA_ICC_PROFILE => Type::ICC_PROFILE,
             #[cfg(feature = "ffmpeg_4_3")]
             AV_PKT_DATA_DOVI_CONF => Type::DOVI_CONF,
+            #[allow(unreachable_patterns)]
+            _ => unimplemented!(),
         }
     }
 }
@@ -142,6 +144,8 @@ impl Into<AVPacketSideDataType> for Type {
             Type::ICC_PROFILE => AV_PKT_DATA_ICC_PROFILE,
             #[cfg(feature = "ffmpeg_4_3")]
             Type::DOVI_CONF => AV_PKT_DATA_DOVI_CONF,
+            #[allow(unreachable_patterns)]
+            _ => unimplemented!(),
         }
     }
 }

--- a/src/util/format/pixel.rs
+++ b/src/util/format/pixel.rs
@@ -687,6 +687,8 @@ impl From<AVPixelFormat> for Pixel {
             AV_PIX_FMT_RPI4_8 => Pixel::RPI4_8,
             #[cfg(feature = "rpi")]
             AV_PIX_FMT_RPI4_10 => Pixel::RPI4_10,
+            #[allow(unreachable_patterns)]
+            _ => unimplemented!(),
         }
     }
 }
@@ -1041,6 +1043,8 @@ impl Into<AVPixelFormat> for Pixel {
             Pixel::RPI4_8 => AV_PIX_FMT_RPI4_8,
             #[cfg(feature = "rpi")]
             Pixel::RPI4_10 => AV_PIX_FMT_RPI4_10,
+            #[allow(unreachable_patterns)]
+            _ => unimplemented!(),
         }
     }
 }

--- a/src/util/frame/side_data.rs
+++ b/src/util/frame/side_data.rs
@@ -91,6 +91,8 @@ impl From<AVFrameSideDataType> for Type {
 
             #[cfg(feature = "ffmpeg_4_3")]
             AV_FRAME_DATA_VIDEO_ENC_PARAMS => Type::VIDEO_ENC_PARAMS,
+            #[allow(unreachable_patterns)]
+            _ => unimplemented!(),
         }
     }
 }
@@ -132,6 +134,8 @@ impl Into<AVFrameSideDataType> for Type {
 
             #[cfg(feature = "ffmpeg_4_3")]
             Type::VIDEO_ENC_PARAMS => AV_FRAME_DATA_VIDEO_ENC_PARAMS,
+            #[allow(unreachable_patterns)]
+            _ => unimplemented!(),
         }
     }
 }


### PR DESCRIPTION
Currently (and every time there's an ffmpeg update), if the crate is not updated immediately (with https://github.com/zmwangx/rust-ffmpeg/pull/60 for example), it just fails building because some new cases are not matched in some arms.

Instead of hard-failing, I suggest we carry on with the compilation properly (so we don't break entirely when someone has a too recent ffmpeg), and for the unlikely case of someone using straight a way a new feature, just raise an unimplemented!()

That would really reduce the headache whenever distros update very fast their packages, and we are a bit behind :)