### PR TITLE
A few small additions

### DIFF
--- a/src/codec/context.rs
+++ b/src/codec/context.rs
@@ -112,6 +112,22 @@ impl Context {
             }
         }
     }
+
+    pub fn width(&self) -> u32 {
+        unsafe { (*self.as_ptr()).width as u32 }
+    }
+
+    pub fn height(&self) -> u32 {
+        unsafe { (*self.as_ptr()).height as u32 }
+    }
+
+    pub fn coded_width(&self) -> u32 {
+        unsafe { (*self.as_ptr()).coded_width as u32 }
+    }
+
+    pub fn coded_height(&self) -> u32 {
+        unsafe { (*self.as_ptr()).coded_height as u32 }
+    }
 }
 
 impl Default for Context {

--- a/src/codec/id.rs
+++ b/src/codec/id.rs
@@ -1139,6 +1139,8 @@ impl From<AVCodecID> for Id {
             AV_CODEC_ID_HCA => Id::HCA,
             #[cfg(feature = "ffmpeg_4_3")]
             AV_CODEC_ID_EPG => Id::EPG,
+
+            _ => panic!("Unknown AVCodecID value. You maybe using an incompatible version of FFMpeg."),
         }
     }
 }

--- a/src/codec/packet/side_data.rs
+++ b/src/codec/packet/side_data.rs
@@ -94,6 +94,8 @@ impl From<AVPacketSideDataType> for Type {
             AV_PKT_DATA_ICC_PROFILE => Type::ICC_PROFILE,
             #[cfg(feature = "ffmpeg_4_3")]
             AV_PKT_DATA_DOVI_CONF => Type::DOVI_CONF,
+
+            _ => panic!("Unknown AVPacketSideDataType value. You maybe using an incompatible version of FFMpeg."),
         }
     }
 }

--- a/src/filter/filter.rs
+++ b/src/filter/filter.rs
@@ -24,6 +24,7 @@ impl Filter {
 }
 
 impl Filter {
+
     pub fn name(&self) -> &str {
         unsafe { from_utf8_unchecked(CStr::from_ptr((*self.as_ptr()).name).to_bytes()) }
     }

--- a/src/util/format/pixel.rs
+++ b/src/util/format/pixel.rs
@@ -687,6 +687,8 @@ impl From<AVPixelFormat> for Pixel {
             AV_PIX_FMT_RPI4_8 => Pixel::RPI4_8,
             #[cfg(feature = "rpi")]
             AV_PIX_FMT_RPI4_10 => Pixel::RPI4_10,
+
+            _ => panic!("Unknown AVPixelFormat value. You maybe using an incompatible version of FFMpeg."),
         }
     }
 }

--- a/src/util/frame/side_data.rs
+++ b/src/util/frame/side_data.rs
@@ -91,6 +91,8 @@ impl From<AVFrameSideDataType> for Type {
 
             #[cfg(feature = "ffmpeg_4_3")]
             AV_FRAME_DATA_VIDEO_ENC_PARAMS => Type::VIDEO_ENC_PARAMS,
+
+            _ => panic!("Unknown AVFrameSideDataType value. You maybe using an incompatible version of FFMpeg."),
         }
     }
 }


### PR DESCRIPTION
A while ago I made some extension traits for a personal project. I decided it made sense to add them to the project. There are three main things:

1. Add the ability to link filters together (commit 3430c23)
2. Added the ability to seek to a frame in a format::context::Input (commit 5e651ae)
3. Added the ability to get the dimensions and coded dimensions of a codec::context::Context (commit 5d9c94d)

Additionally, in order to get it to build, I added some panic statements to some matches (commit 5306439).  Essentially, it makes it that if someone (like me) has a newer version of ffmpeg, they'll still be able to use the library (it'll just panic if they try to do anything that isn't supported).

I only added these in places where it was necessary in order to build. Personally, I think it would be a good idea to add them else where (and I'm more than willing to do it myself), but I thought I should check first.