### PR TITLE
fix build on platforms where std::os::raw::c_char is not i8

### DIFF
--- a/src/util/error.rs
+++ b/src/util/error.rs
@@ -201,8 +201,7 @@ fn index(error: &Error) -> usize {
 }
 
 // XXX: the length has to be synced with the number of errors
-static mut STRINGS: [[c_char; AV_ERROR_MAX_STRING_SIZE]; 27] =
-    [[0_i8; AV_ERROR_MAX_STRING_SIZE]; 27];
+static mut STRINGS: [[c_char; AV_ERROR_MAX_STRING_SIZE]; 27] = [[0; AV_ERROR_MAX_STRING_SIZE]; 27];
 
 pub fn register_all() {
     unsafe {


### PR DESCRIPTION
c_char may be i8 or u8, depending on target platform: https://doc.rust-lang.org/std/os/raw/type.c_char.html

(you can see the macros defining it conditionally at https://doc.rust-lang.org/src/std/os/raw/mod.rs.html#48-131 if you're curious which targets are impacted by this bug)

`cargo test` builds and passes on ppc64le with this change :)