### PR TITLE
Added software::resampling::Context::get_out_samples to bind swr_get_out_samples

### DIFF
--- a/src/software/resampling/context.rs
+++ b/src/software/resampling/context.rs
@@ -1,3 +1,4 @@
+use std::convert::TryFrom;
 use std::ptr;
 
 use super::Delay;
@@ -130,6 +131,23 @@ impl Context {
             match swr_get_delay(self.as_ptr() as *mut _, 1) {
                 0 => None,
                 _ => Some(Delay::from(self)),
+            }
+        }
+    }
+
+    /// Returns an upper bound on the number of samples the next [`run`][Self::run] call will
+    /// output, if called with `in_samples` of input samples.
+    ///
+    /// Returns an error if `in_samples` exceeds `i32::MAX`.
+    pub fn get_out_samples(&self, in_samples: u32) -> Result<u32, Error> {
+        // We return an error in case `in_samples` is bigger than `i32::MAX` because the
+        // libswresample API wasn't designed very well here and accepts a signed integer as the
+        // number of samples, for some reason.
+        let in_samples = i32::try_from(in_samples).map_err(|_| Error::InvalidData)?;
+        unsafe {
+            match swr_get_out_samples(self.as_ptr() as *mut _, in_samples) {
+                n if n >= 0 => Ok(n as u32),
+                e => Err(Error::from(e)),
             }
         }
     }


### PR DESCRIPTION
When resampling, to make sure no samples are buffered internally, it's important to have a buffer large enough to fit all these samples. Up to this point there was no way of knowing how many samples should be allocated up front, so this PR adds a binding to that from libswresample.

Unresolved questions:
- [ ] `swr_get_out_samples` accepts an `int`, but I'm sure it expects the input sample count to be positive. It's probably an oversight on libswresample's part, so I _kind of_ fixed it, and made the method return an error if the argument passed does not fit in an `i32`. It feels quite janky though so I need an opinion from the maintainers.