### PR TITLE
Fix get best stream

### DIFF
--- a/src/format/context/common.rs
+++ b/src/format/context/common.rs
@@ -176,7 +176,7 @@ impl<'a> Best<'a> {
                 0,
             );
 
-            if index >= 0 && !decoder.is_null() {
+            if index >= 0 {
                 Some(Stream::wrap(self.context, index as usize))
             } else {
                 None


### PR DESCRIPTION
In ffmpeg 5.0, `av_find_best_stream` does not set `decoder` if the input to that parameter is a null ptr. This resulted in the wrapper for `Stream::best` not working in ffmpeg 5.0. This change removes the check that `decoder` is set, which allows the proper result to be returned.