### PR TITLE
Fix incorrect sizes for plane and data slices for audio frames.

### DIFF
--- a/src/util/frame/audio.rs
+++ b/src/util/frame/audio.rs
@@ -144,7 +144,18 @@ impl Audio {
             panic!("unsupported type");
         }
 
-        unsafe { slice::from_raw_parts((*self.as_ptr()).data[index] as *const T, self.samples()) }
+        if self.is_planar() {
+            unsafe {
+                slice::from_raw_parts((*self.as_ptr()).data[index] as *const T, self.samples())
+            }
+        } else {
+            unsafe {
+                slice::from_raw_parts(
+                    (*self.as_ptr()).data[0] as *const T,
+                    self.samples() * usize::from(self.channels()),
+                )
+            }
+        }
     }
 
     #[inline]
@@ -157,8 +168,20 @@ impl Audio {
             panic!("unsupported type");
         }
 
-        unsafe {
-            slice::from_raw_parts_mut((*self.as_mut_ptr()).data[index] as *mut T, self.samples())
+        if self.is_planar() {
+            unsafe {
+                slice::from_raw_parts_mut(
+                    (*self.as_mut_ptr()).data[index] as *mut T,
+                    self.samples(),
+                )
+            }
+        } else {
+            unsafe {
+                slice::from_raw_parts_mut(
+                    (*self.as_mut_ptr()).data[0] as *mut T,
+                    self.samples() * usize::from(self.channels()),
+                )
+            }
         }
     }
 
@@ -171,7 +194,7 @@ impl Audio {
         unsafe {
             slice::from_raw_parts(
                 (*self.as_ptr()).data[index],
-                (*self.as_ptr()).linesize[index] as usize,
+                (*self.as_ptr()).linesize[0] as usize,
             )
         }
     }
@@ -185,7 +208,7 @@ impl Audio {
         unsafe {
             slice::from_raw_parts_mut(
                 (*self.as_mut_ptr()).data[index],
-                (*self.as_ptr()).linesize[index] as usize,
+                (*self.as_ptr()).linesize[0] as usize,
             )
         }
     }


### PR DESCRIPTION
This pull request fixes two bugs:

- The size of a plane created by [`frame::Audio::plane()`](https://docs.rs/ffmpeg-next/latest/ffmpeg_next/util/frame/audio/struct.Audio.html#method.plane) for a packed audio frame with more than one channel was incorrectly set to the number of samples. It is now changed to be the number of samples times the number of channels.
- The size of the slice created by [`frame::Audio::data(n)`](https://docs.rs/ffmpeg-next/latest/ffmpeg_next/util/frame/audio/struct.Audio.html#method.data) for `n > 0` was incorrectly set to `0`. It is now changed to be the same as for `n=0`.

Some explanations can be found at the doxygen documentation for [AVFrame](https://ffmpeg.org/doxygen/trunk/structAVFrame.html#aa52bfc6605f6a3059a0c3226cc0f6567).
In particular:

> ◆ linesize
>
> int AVFrame::linesize[AV_NUM_DATA_POINTERS]
> ...
> For audio, only linesize[0] may be set. For planar audio, each channel plane must be the same size.
