### PR TITLE
Implement support for non-exhaustive enums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords      = ["ffmpeg", "multimedia", "video", "audio"]
 categories    = ["multimedia"]
 
 [features]
-default = ["codec", "device", "filter", "format", "software-resampling", "software-scaling"]
+default = ["codec", "device", "filter", "format", "software-resampling", "software-scaling", "non-exhaustive-enums"]
 
 # ffmpeg<xy> are obsolete features kept for backward compatibility purposes and
 # don't do anything anymore (equivalents are automatically specified through
@@ -28,6 +28,9 @@ ffmpeg4 = []
 
 static = ["ffmpeg-sys-next/static"]
 build  = ["static", "ffmpeg-sys-next/build"]
+
+# mark enums in generated bindings as #[non_exhaustive]
+non-exhaustive-enums = ["ffmpeg-sys-next/non-exhaustive-enums"]
 
 # licensing
 build-license-gpl      = ["ffmpeg-sys-next/build-license-gpl"]

--- a/src/codec/audio_service.rs
+++ b/src/codec/audio_service.rs
@@ -28,6 +28,7 @@ impl From<AVAudioServiceType> for AudioService {
             AV_AUDIO_SERVICE_TYPE_KARAOKE => AudioService::Karaoke,
             AV_AUDIO_SERVICE_TYPE_NB => AudioService::Main,
 
+            #[cfg(feature = "non-exhaustive-enums")]
             _ => unimplemented!(),
         }
     }

--- a/src/codec/audio_service.rs
+++ b/src/codec/audio_service.rs
@@ -27,6 +27,8 @@ impl From<AVAudioServiceType> for AudioService {
             AV_AUDIO_SERVICE_TYPE_VOICE_OVER => AudioService::VoiceOver,
             AV_AUDIO_SERVICE_TYPE_KARAOKE => AudioService::Karaoke,
             AV_AUDIO_SERVICE_TYPE_NB => AudioService::Main,
+
+            _ => unimplemented!(),
         }
     }
 }

--- a/src/codec/discard.rs
+++ b/src/codec/discard.rs
@@ -23,6 +23,7 @@ impl From<AVDiscard> for Discard {
             AVDISCARD_NONKEY => Discard::NonKey,
             AVDISCARD_ALL => Discard::All,
 
+            #[cfg(feature = "non-exhaustive-enums")]
             _ => unimplemented!(),
         }
     }

--- a/src/codec/discard.rs
+++ b/src/codec/discard.rs
@@ -22,6 +22,8 @@ impl From<AVDiscard> for Discard {
             AVDISCARD_NONINTRA => Discard::NonIntra,
             AVDISCARD_NONKEY => Discard::NonKey,
             AVDISCARD_ALL => Discard::All,
+
+            _ => unimplemented!(),
         }
     }
 }

--- a/src/codec/field_order.rs
+++ b/src/codec/field_order.rs
@@ -20,6 +20,8 @@ impl From<AVFieldOrder> for FieldOrder {
             AV_FIELD_BB => FieldOrder::BB,
             AV_FIELD_TB => FieldOrder::TB,
             AV_FIELD_BT => FieldOrder::BT,
+
+            _ => unimplemented!(),
         }
     }
 }

--- a/src/codec/field_order.rs
+++ b/src/codec/field_order.rs
@@ -21,6 +21,7 @@ impl From<AVFieldOrder> for FieldOrder {
             AV_FIELD_TB => FieldOrder::TB,
             AV_FIELD_BT => FieldOrder::BT,
 
+            #[cfg(feature = "non-exhaustive-enums")]
             _ => unimplemented!(),
         }
     }

--- a/src/codec/id.rs
+++ b/src/codec/id.rs
@@ -1296,6 +1296,7 @@ impl From<AVCodecID> for Id {
             #[cfg(feature = "ffmpeg_6_0")]
             AV_CODEC_ID_ANULL => Id::ANULL,
 
+            #[cfg(feature = "non-exhaustive-enums")]
             _ => unimplemented!(),
         }
     }

--- a/src/codec/id.rs
+++ b/src/codec/id.rs
@@ -1295,6 +1295,8 @@ impl From<AVCodecID> for Id {
             AV_CODEC_ID_VNULL => Id::VNULL,
             #[cfg(feature = "ffmpeg_6_0")]
             AV_CODEC_ID_ANULL => Id::ANULL,
+
+            _ => unimplemented!(),
         }
     }
 }

--- a/src/codec/packet/side_data.rs
+++ b/src/codec/packet/side_data.rs
@@ -107,6 +107,7 @@ impl From<AVPacketSideDataType> for Type {
             #[cfg(feature = "ffmpeg_5_0")]
             AV_PKT_DATA_DYNAMIC_HDR10_PLUS => Type::DYNAMIC_HDR10_PLUS,
 
+            #[cfg(feature = "non-exhaustive-enums")]
             _ => unimplemented!(),
         }
     }

--- a/src/codec/packet/side_data.rs
+++ b/src/codec/packet/side_data.rs
@@ -106,6 +106,8 @@ impl From<AVPacketSideDataType> for Type {
 
             #[cfg(feature = "ffmpeg_5_0")]
             AV_PKT_DATA_DYNAMIC_HDR10_PLUS => Type::DYNAMIC_HDR10_PLUS,
+
+            _ => unimplemented!(),
         }
     }
 }

--- a/src/codec/subtitle/mod.rs
+++ b/src/codec/subtitle/mod.rs
@@ -30,6 +30,7 @@ impl From<AVSubtitleType> for Type {
             SUBTITLE_TEXT => Type::Text,
             SUBTITLE_ASS => Type::Ass,
 
+            #[cfg(feature = "non-exhaustive-enums")]
             _ => unimplemented!(),
         }
     }

--- a/src/codec/subtitle/mod.rs
+++ b/src/codec/subtitle/mod.rs
@@ -29,6 +29,8 @@ impl From<AVSubtitleType> for Type {
             SUBTITLE_BITMAP => Type::Bitmap,
             SUBTITLE_TEXT => Type::Text,
             SUBTITLE_ASS => Type::Ass,
+
+            _ => unimplemented!(),
         }
     }
 }

--- a/src/software/resampling/dither.rs
+++ b/src/software/resampling/dither.rs
@@ -35,6 +35,7 @@ impl From<SwrDitherType> for Dither {
             SWR_DITHER_NS_HIGH_SHIBATA => Dither::NoiseShapingHighShibata,
             SWR_DITHER_NB => Dither::None,
 
+            #[cfg(feature = "non-exhaustive-enums")]
             _ => unimplemented!(),
         }
     }

--- a/src/software/resampling/dither.rs
+++ b/src/software/resampling/dither.rs
@@ -34,6 +34,8 @@ impl From<SwrDitherType> for Dither {
             SWR_DITHER_NS_LOW_SHIBATA => Dither::NoiseShapingLowShibata,
             SWR_DITHER_NS_HIGH_SHIBATA => Dither::NoiseShapingHighShibata,
             SWR_DITHER_NB => Dither::None,
+
+            _ => unimplemented!(),
         }
     }
 }

--- a/src/software/resampling/engine.rs
+++ b/src/software/resampling/engine.rs
@@ -14,6 +14,7 @@ impl From<SwrEngine> for Engine {
             SWR_ENGINE_SOXR => Engine::SoundExchange,
             SWR_ENGINE_NB => Engine::Software,
 
+            #[cfg(feature = "non-exhaustive-enums")]
             _ => unimplemented!(),
         }
     }

--- a/src/software/resampling/engine.rs
+++ b/src/software/resampling/engine.rs
@@ -13,6 +13,8 @@ impl From<SwrEngine> for Engine {
             SWR_ENGINE_SWR => Engine::Software,
             SWR_ENGINE_SOXR => Engine::SoundExchange,
             SWR_ENGINE_NB => Engine::Software,
+
+            _ => unimplemented!(),
         }
     }
 }

--- a/src/software/resampling/filter.rs
+++ b/src/software/resampling/filter.rs
@@ -14,6 +14,8 @@ impl From<SwrFilterType> for Filter {
             SWR_FILTER_TYPE_CUBIC => Filter::Cubic,
             SWR_FILTER_TYPE_BLACKMAN_NUTTALL => Filter::BlackmanNuttall,
             SWR_FILTER_TYPE_KAISER => Filter::Kaiser,
+
+            _ => unimplemented!(),
         }
     }
 }

--- a/src/software/resampling/filter.rs
+++ b/src/software/resampling/filter.rs
@@ -15,6 +15,7 @@ impl From<SwrFilterType> for Filter {
             SWR_FILTER_TYPE_BLACKMAN_NUTTALL => Filter::BlackmanNuttall,
             SWR_FILTER_TYPE_KAISER => Filter::Kaiser,
 
+            #[cfg(feature = "non-exhaustive-enums")]
             _ => unimplemented!(),
         }
     }

--- a/src/util/chroma/location.rs
+++ b/src/util/chroma/location.rs
@@ -24,6 +24,7 @@ impl From<AVChromaLocation> for Location {
             AVCHROMA_LOC_BOTTOM => Location::Bottom,
             AVCHROMA_LOC_NB => Location::Unspecified,
 
+            #[cfg(feature = "non-exhaustive-enums")]
             _ => unimplemented!(),
         }
     }

--- a/src/util/chroma/location.rs
+++ b/src/util/chroma/location.rs
@@ -23,6 +23,8 @@ impl From<AVChromaLocation> for Location {
             AVCHROMA_LOC_BOTTOMLEFT => Location::BottomLeft,
             AVCHROMA_LOC_BOTTOM => Location::Bottom,
             AVCHROMA_LOC_NB => Location::Unspecified,
+
+            _ => unimplemented!(),
         }
     }
 }

--- a/src/util/color/primaries.rs
+++ b/src/util/color/primaries.rs
@@ -67,6 +67,7 @@ impl From<AVColorPrimaries> for Primaries {
             #[cfg(feature = "ffmpeg_4_3")]
             AVCOL_PRI_EBU3213 => Primaries::EBU3213,
 
+            #[cfg(feature = "non-exhaustive-enums")]
             _ => unimplemented!(),
         }
     }

--- a/src/util/color/primaries.rs
+++ b/src/util/color/primaries.rs
@@ -66,6 +66,8 @@ impl From<AVColorPrimaries> for Primaries {
             AVCOL_PRI_JEDEC_P22 => Primaries::JEDEC_P22,
             #[cfg(feature = "ffmpeg_4_3")]
             AVCOL_PRI_EBU3213 => Primaries::EBU3213,
+
+            _ => unimplemented!(),
         }
     }
 }

--- a/src/util/color/range.rs
+++ b/src/util/color/range.rs
@@ -32,6 +32,7 @@ impl From<AVColorRange> for Range {
             AVCOL_RANGE_JPEG => Range::JPEG,
             AVCOL_RANGE_NB => Range::Unspecified,
 
+            #[cfg(feature = "non-exhaustive-enums")]
             _ => unimplemented!(),
         }
     }

--- a/src/util/color/range.rs
+++ b/src/util/color/range.rs
@@ -31,6 +31,8 @@ impl From<AVColorRange> for Range {
             AVCOL_RANGE_MPEG => Range::MPEG,
             AVCOL_RANGE_JPEG => Range::JPEG,
             AVCOL_RANGE_NB => Range::Unspecified,
+
+            _ => unimplemented!(),
         }
     }
 }

--- a/src/util/color/space.rs
+++ b/src/util/color/space.rs
@@ -59,6 +59,8 @@ impl From<AVColorSpace> for Space {
             AVCOL_SPC_CHROMA_DERIVED_NCL => Space::ChromaDerivedNCL,
             AVCOL_SPC_CHROMA_DERIVED_CL => Space::ChromaDerivedCL,
             AVCOL_SPC_ICTCP => Space::ICTCP,
+
+            _ => unimplemented!(),
         }
     }
 }

--- a/src/util/color/space.rs
+++ b/src/util/color/space.rs
@@ -60,6 +60,7 @@ impl From<AVColorSpace> for Space {
             AVCOL_SPC_CHROMA_DERIVED_CL => Space::ChromaDerivedCL,
             AVCOL_SPC_ICTCP => Space::ICTCP,
 
+            #[cfg(feature = "non-exhaustive-enums")]
             _ => unimplemented!(),
         }
     }

--- a/src/util/color/transfer_characteristic.rs
+++ b/src/util/color/transfer_characteristic.rs
@@ -63,6 +63,8 @@ impl From<AVColorTransferCharacteristic> for TransferCharacteristic {
             AVCOL_TRC_SMPTE2084 => TransferCharacteristic::SMPTE2084,
             AVCOL_TRC_SMPTE428 => TransferCharacteristic::SMPTE428,
             AVCOL_TRC_ARIB_STD_B67 => TransferCharacteristic::ARIB_STD_B67,
+
+            _ => unimplemented!(),
         }
     }
 }

--- a/src/util/color/transfer_characteristic.rs
+++ b/src/util/color/transfer_characteristic.rs
@@ -64,6 +64,7 @@ impl From<AVColorTransferCharacteristic> for TransferCharacteristic {
             AVCOL_TRC_SMPTE428 => TransferCharacteristic::SMPTE428,
             AVCOL_TRC_ARIB_STD_B67 => TransferCharacteristic::ARIB_STD_B67,
 
+            #[cfg(feature = "non-exhaustive-enums")]
             _ => unimplemented!(),
         }
     }

--- a/src/util/format/pixel.rs
+++ b/src/util/format/pixel.rs
@@ -809,6 +809,7 @@ impl From<AVPixelFormat> for Pixel {
             #[cfg(feature = "rpi")]
             AV_PIX_FMT_RPI4_10 => Pixel::RPI4_10,
 
+            #[cfg(feature = "non-exhaustive-enums")]
             _ => unimplemented!(),
         }
     }

--- a/src/util/format/pixel.rs
+++ b/src/util/format/pixel.rs
@@ -808,6 +808,8 @@ impl From<AVPixelFormat> for Pixel {
             AV_PIX_FMT_RPI4_8 => Pixel::RPI4_8,
             #[cfg(feature = "rpi")]
             AV_PIX_FMT_RPI4_10 => Pixel::RPI4_10,
+
+            _ => unimplemented!(),
         }
     }
 }

--- a/src/util/format/sample.rs
+++ b/src/util/format/sample.rs
@@ -87,6 +87,7 @@ impl From<AVSampleFormat> for Sample {
 
             AV_SAMPLE_FMT_NB => Sample::None,
 
+            #[cfg(feature = "non-exhaustive-enums")]
             _ => unimplemented!(),
         }
     }

--- a/src/util/format/sample.rs
+++ b/src/util/format/sample.rs
@@ -86,6 +86,8 @@ impl From<AVSampleFormat> for Sample {
             AV_SAMPLE_FMT_DBLP => Sample::F64(Type::Planar),
 
             AV_SAMPLE_FMT_NB => Sample::None,
+
+            _ => unimplemented!(),
         }
     }
 }

--- a/src/util/frame/side_data.rs
+++ b/src/util/frame/side_data.rs
@@ -126,6 +126,8 @@ impl From<AVFrameSideDataType> for Type {
 
             #[cfg(feature = "ffmpeg_6_0")]
             AV_FRAME_DATA_AMBIENT_VIEWING_ENVIRONMENT => Type::AMBIENT_VIEWING_ENVIRONMENT,
+
+            _ => unimplemented!(),
         }
     }
 }

--- a/src/util/frame/side_data.rs
+++ b/src/util/frame/side_data.rs
@@ -127,6 +127,7 @@ impl From<AVFrameSideDataType> for Type {
             #[cfg(feature = "ffmpeg_6_0")]
             AV_FRAME_DATA_AMBIENT_VIEWING_ENVIRONMENT => Type::AMBIENT_VIEWING_ENVIRONMENT,
 
+            #[cfg(feature = "non-exhaustive-enums")]
             _ => unimplemented!(),
         }
     }

--- a/src/util/mathematics/rounding.rs
+++ b/src/util/mathematics/rounding.rs
@@ -22,6 +22,7 @@ impl From<AVRounding> for Rounding {
             AV_ROUND_NEAR_INF => Rounding::NearInfinity,
             AV_ROUND_PASS_MINMAX => Rounding::PassMinMax,
 
+            #[cfg(feature = "non-exhaustive-enums")]
             _ => unimplemented!(),
         }
     }

--- a/src/util/mathematics/rounding.rs
+++ b/src/util/mathematics/rounding.rs
@@ -21,6 +21,8 @@ impl From<AVRounding> for Rounding {
             AV_ROUND_UP => Rounding::Up,
             AV_ROUND_NEAR_INF => Rounding::NearInfinity,
             AV_ROUND_PASS_MINMAX => Rounding::PassMinMax,
+
+            _ => unimplemented!(),
         }
     }
 }

--- a/src/util/media.rs
+++ b/src/util/media.rs
@@ -22,6 +22,8 @@ impl From<AVMediaType> for Type {
             AVMEDIA_TYPE_SUBTITLE => Type::Subtitle,
             AVMEDIA_TYPE_ATTACHMENT => Type::Attachment,
             AVMEDIA_TYPE_NB => Type::Unknown,
+
+            _ => unimplemented!(),
         }
     }
 }

--- a/src/util/media.rs
+++ b/src/util/media.rs
@@ -23,6 +23,7 @@ impl From<AVMediaType> for Type {
             AVMEDIA_TYPE_ATTACHMENT => Type::Attachment,
             AVMEDIA_TYPE_NB => Type::Unknown,
 
+            #[cfg(feature = "non-exhaustive-enums")]
             _ => unimplemented!(),
         }
     }

--- a/src/util/option/mod.rs
+++ b/src/util/option/mod.rs
@@ -53,6 +53,8 @@ impl From<AVOptionType> for Type {
             AV_OPT_TYPE_CHANNEL_LAYOUT => Type::ChannelLayout,
             #[cfg(feature = "ffmpeg_5_1")]
             AV_OPT_TYPE_CHLAYOUT => Type::ChannelLayout,
+
+            _ => unimplemented!(),
         }
     }
 }

--- a/src/util/option/mod.rs
+++ b/src/util/option/mod.rs
@@ -54,6 +54,7 @@ impl From<AVOptionType> for Type {
             #[cfg(feature = "ffmpeg_5_1")]
             AV_OPT_TYPE_CHLAYOUT => Type::ChannelLayout,
 
+            #[cfg(feature = "non-exhaustive-enums")]
             _ => unimplemented!(),
         }
     }

--- a/src/util/picture.rs
+++ b/src/util/picture.rs
@@ -26,6 +26,7 @@ impl From<AVPictureType> for Type {
             AV_PICTURE_TYPE_SP => Type::SP,
             AV_PICTURE_TYPE_BI => Type::BI,
 
+            #[cfg(feature = "non-exhaustive-enums")]
             _ => unimplemented!(),
         }
     }

--- a/src/util/picture.rs
+++ b/src/util/picture.rs
@@ -25,6 +25,8 @@ impl From<AVPictureType> for Type {
             AV_PICTURE_TYPE_SI => Type::SI,
             AV_PICTURE_TYPE_SP => Type::SP,
             AV_PICTURE_TYPE_BI => Type::BI,
+
+            _ => unimplemented!(),
         }
     }
 }


### PR DESCRIPTION
This PR requires [this](https://github.com/zmwangx/rust-ffmpeg-sys/pull/48) `ffmpeg-sys-next` PR to be merged first.

This PR adds the feature "non-exhaustive-enums" as requested in zmwangx/rust-ffmpeg-sys#46. This allows users to compile the ffmpeg-next crate(s) even when their locally installed FFmpeg dev files are newer than the target version.

Disabling the feature can be useful for library devs when updating ffmpeg-next to a newer version of FFmpeg. By disabling it, the compiler will error on enum matches that don't handle all enum values (making it harder to miss new enum values)

I think including this as a default feature is useful.