### PR TITLE
Add bits per pixel fn to Descriptor struct

### DIFF
--- a/src/util/format/pixel.rs
+++ b/src/util/format/pixel.rs
@@ -426,6 +426,10 @@ impl Descriptor {
     pub fn log2_chroma_h(self) -> u8 {
         unsafe { (*self.as_ptr()).log2_chroma_h }
     }
+
+    pub fn bits_per_pixel(&self) -> i32 {
+        unsafe { av_get_bits_per_pixel(self.as_ptr()) }
+    }
 }
 
 impl From<AVPixelFormat> for Pixel {


### PR DESCRIPTION
Adding this function to `pixel::Descriptor` would enable library users to determine the bit depth of a stream or `frame::Video` by taking their format and calling this function without needing to call into `ffmpeg-sys-next` directly