### PR TITLE
Enable creation of codec context for specific codec

### DIFF
--- a/src/codec/context.rs
+++ b/src/codec/context.rs
@@ -41,6 +41,15 @@ impl Context {
         }
     }
 
+    pub fn new_with_codec(codec: Codec) -> Self {
+        unsafe {
+            Context {
+                ptr: avcodec_alloc_context3(codec.as_ptr()),
+                owner: None,
+            }
+        }
+    }
+
     pub fn from_parameters<P: Into<Parameters>>(parameters: P) -> Result<Self, Error> {
         let parameters = parameters.into();
         let mut context = Self::new();

--- a/src/codec/decoder/decoder.rs
+++ b/src/codec/decoder/decoder.rs
@@ -54,7 +54,9 @@ impl Decoder {
     }
 
     pub fn video(self) -> Result<Video, Error> {
-        if let Some(codec) = super::find(self.id()) {
+        if let Some(codec) = self.0.codec() {
+            self.open_as(codec).and_then(|o| o.video())
+        } else if let Some(codec) = super::find(self.id()) {
             self.open_as(codec).and_then(|o| o.video())
         } else {
             Err(Error::DecoderNotFound)


### PR DESCRIPTION
This allows user to do similar things as setting `-vcodec [codec]` on the FFmpeg CLI.

example code:
```
let vp9_dec = find_by_name("libvpx-vp9").expect('failed to find codec');
let mut vp9_ctx_dec = ffmpeg_next::codec::Context::new_with_codec(vp9_dec);
vp9_ctx_dec.set_parameters(parameters).expect('failed to set parameters');
```