### PR TITLE
Add ffmpeg 6.0 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     container: jrottenberg/ffmpeg:${{ matrix.ffmpeg_version }}-ubuntu
     strategy:
       matrix:
-        ffmpeg_version: ["3.4", "4.0", "4.1", "4.2", "4.3", "4.4", "5.0", "5.1"]
+        ffmpeg_version: ["3.4", "4.0", "4.1", "4.2", "4.3", "4.4", "5.0", "5.1", "6.0"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     container: jrottenberg/ffmpeg:${{ matrix.ffmpeg_version }}-ubuntu
     strategy:
       matrix:
-        ffmpeg_version: ["3.4", "4.0", "4.1", "4.2", "4.3", "4.4", "5.0", "5.1", "6.0"]
+        ffmpeg_version: ["3.4", "4.0", "4.1", "4.2", "4.3", "4.4", "5.0", "5.1"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,5 +113,5 @@ version  = "0.23"
 optional = true
 
 [dependencies.ffmpeg-sys-next]
-version = "6.0.0"
+version = "6.0.1"
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ffmpeg-next"
-version = "5.1.1"
+version = "6.0.0"
 build   = "build.rs"
 
 authors = ["meh. <meh@schizofreni.co>", "Zhiming Wang <i@zhimingwang.org>"]
@@ -113,5 +113,5 @@ version  = "0.23"
 optional = true
 
 [dependencies.ffmpeg-sys-next]
-version = "5.1.1"
+version = "6.0.0"
 default-features = false

--- a/src/codec/capabilities.rs
+++ b/src/codec/capabilities.rs
@@ -5,6 +5,7 @@ bitflags! {
     pub struct Capabilities: c_uint {
         const DRAW_HORIZ_BAND     = AV_CODEC_CAP_DRAW_HORIZ_BAND;
         const DR1                 = AV_CODEC_CAP_DR1;
+        #[cfg(not(feature = "ffmpeg_6_0"))]
         const TRUNCATED           = AV_CODEC_CAP_TRUNCATED;
         const DELAY               = AV_CODEC_CAP_DELAY;
         const SMALL_LAST_FRAME    = AV_CODEC_CAP_SMALL_LAST_FRAME;
@@ -16,9 +17,14 @@ bitflags! {
         const FRAME_THREADS       = AV_CODEC_CAP_FRAME_THREADS;
         const SLICE_THREADS       = AV_CODEC_CAP_SLICE_THREADS;
         const PARAM_CHANGE        = AV_CODEC_CAP_PARAM_CHANGE;
+        #[cfg(not(feature = "ffmpeg_6_0"))]
         const AUTO_THREADS        = AV_CODEC_CAP_AUTO_THREADS;
+        #[cfg(feature = "ffmpeg_6_0")]
+        const OTHER_THREADS       = AV_CODEC_CAP_OTHER_THREADS;
         const VARIABLE_FRAME_SIZE = AV_CODEC_CAP_VARIABLE_FRAME_SIZE;
+        #[cfg(not(feature = "ffmpeg_6_0"))]
         const INTRA_ONLY          = AV_CODEC_CAP_INTRA_ONLY;
+        #[cfg(not(feature = "ffmpeg_6_0"))]
         const LOSSLESS            = AV_CODEC_CAP_LOSSLESS;
     }
 }

--- a/src/codec/context.rs
+++ b/src/codec/context.rs
@@ -102,7 +102,9 @@ impl Context {
             (*self.as_mut_ptr()).thread_type = config.kind.into();
             (*self.as_mut_ptr()).thread_count = config.count as c_int;
             #[cfg(not(feature = "ffmpeg_6_0"))]
-            { (*self.as_mut_ptr()).thread_safe_callbacks = if config.safe { 1 } else { 0 }; }
+            {
+                (*self.as_mut_ptr()).thread_safe_callbacks = if config.safe { 1 } else { 0 };
+            }
         }
     }
 

--- a/src/codec/context.rs
+++ b/src/codec/context.rs
@@ -101,7 +101,8 @@ impl Context {
         unsafe {
             (*self.as_mut_ptr()).thread_type = config.kind.into();
             (*self.as_mut_ptr()).thread_count = config.count as c_int;
-            (*self.as_mut_ptr()).thread_safe_callbacks = if config.safe { 1 } else { 0 };
+            #[cfg(not(feature = "ffmpeg_6_0"))]
+            { (*self.as_mut_ptr()).thread_safe_callbacks = if config.safe { 1 } else { 0 }; }
         }
     }
 
@@ -110,6 +111,7 @@ impl Context {
             threading::Config {
                 kind: threading::Type::from((*self.as_ptr()).active_thread_type),
                 count: (*self.as_ptr()).thread_count as usize,
+                #[cfg(not(feature = "ffmpeg_6_0"))]
                 safe: (*self.as_ptr()).thread_safe_callbacks != 0,
             }
         }

--- a/src/codec/flag.rs
+++ b/src/codec/flag.rs
@@ -12,6 +12,7 @@ bitflags! {
         const PASS2           = AV_CODEC_FLAG_PASS2;
         const GRAY            = AV_CODEC_FLAG_GRAY;
         const PSNR            = AV_CODEC_FLAG_PSNR;
+        #[cfg(not(feature = "ffmpeg_6_0"))]
         const TRUNCATED       = AV_CODEC_FLAG_TRUNCATED;
         const INTERLACED_DCT  = AV_CODEC_FLAG_INTERLACED_DCT;
         const LOW_DELAY       = AV_CODEC_FLAG_LOW_DELAY;

--- a/src/codec/id.rs
+++ b/src/codec/id.rs
@@ -1233,7 +1233,7 @@ impl From<AVCodecID> for Id {
             AV_CODEC_ID_PHM => Id::PHM,
             #[cfg(feature = "ffmpeg_5_1")]
             AV_CODEC_ID_DFPWM => Id::DFPWM,
-            v => unimplemented!("{v:?} is not supported yet"),
+            v => { eprintln!("{v:?} is not supported yet"); Id::None },
         }
     }
 }

--- a/src/codec/id.rs
+++ b/src/codec/id.rs
@@ -613,6 +613,37 @@ pub enum Id {
     PHM,
     #[cfg(feature = "ffmpeg_5_1")]
     DFPWM,
+
+    #[cfg(feature = "ffmpeg_6_0")]
+    RADIANCE_HDR,
+    #[cfg(feature = "ffmpeg_6_0")]
+    WBMP,
+    #[cfg(feature = "ffmpeg_6_0")]
+    MEDIA100,
+    #[cfg(feature = "ffmpeg_6_0")]
+    VQC,
+    #[cfg(feature = "ffmpeg_6_0")]
+    ADPCM_XMD,
+    #[cfg(feature = "ffmpeg_6_0")]
+    WADY_DPCM,
+    #[cfg(feature = "ffmpeg_6_0")]
+    CBD2_DPCM,
+    #[cfg(feature = "ffmpeg_6_0")]
+    BONK,
+    #[cfg(feature = "ffmpeg_6_0")]
+    MISC4,
+    #[cfg(feature = "ffmpeg_6_0")]
+    APAC,
+    #[cfg(feature = "ffmpeg_6_0")]
+    FTR,
+    #[cfg(feature = "ffmpeg_6_0")]
+    WAVARC,
+    #[cfg(feature = "ffmpeg_6_0")]
+    RKA,
+    #[cfg(feature = "ffmpeg_6_0")]
+    VNULL,
+    #[cfg(feature = "ffmpeg_6_0")]
+    ANULL,
 }
 
 impl Id {
@@ -1233,7 +1264,37 @@ impl From<AVCodecID> for Id {
             AV_CODEC_ID_PHM => Id::PHM,
             #[cfg(feature = "ffmpeg_5_1")]
             AV_CODEC_ID_DFPWM => Id::DFPWM,
-            v => { eprintln!("{v:?} is not supported yet"); Id::None },
+
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_CODEC_ID_RADIANCE_HDR => Id::RADIANCE_HDR,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_CODEC_ID_WBMP => Id::WBMP,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_CODEC_ID_MEDIA100 => Id::MEDIA100,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_CODEC_ID_VQC => Id::VQC,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_CODEC_ID_ADPCM_XMD => Id::ADPCM_XMD,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_CODEC_ID_WADY_DPCM => Id::WADY_DPCM,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_CODEC_ID_CBD2_DPCM => Id::CBD2_DPCM,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_CODEC_ID_BONK => Id::BONK,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_CODEC_ID_MISC4 => Id::MISC4,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_CODEC_ID_APAC => Id::APAC,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_CODEC_ID_FTR => Id::FTR,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_CODEC_ID_WAVARC => Id::WAVARC,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_CODEC_ID_RKA => Id::RKA,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_CODEC_ID_VNULL => Id::VNULL,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_CODEC_ID_ANULL => Id::ANULL,
         }
     }
 }
@@ -1846,6 +1907,37 @@ impl From<Id> for AVCodecID {
             Id::PHM => AV_CODEC_ID_PHM,
             #[cfg(feature = "ffmpeg_5_1")]
             Id::DFPWM => AV_CODEC_ID_DFPWM,
+
+            #[cfg(feature = "ffmpeg_6_0")]
+            Id::RADIANCE_HDR => AV_CODEC_ID_RADIANCE_HDR,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Id::WBMP => AV_CODEC_ID_WBMP,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Id::MEDIA100 => AV_CODEC_ID_MEDIA100,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Id::VQC => AV_CODEC_ID_VQC,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Id::ADPCM_XMD => AV_CODEC_ID_ADPCM_XMD,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Id::WADY_DPCM => AV_CODEC_ID_WADY_DPCM,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Id::CBD2_DPCM => AV_CODEC_ID_CBD2_DPCM,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Id::BONK => AV_CODEC_ID_BONK,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Id::MISC4 => AV_CODEC_ID_MISC4,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Id::APAC => AV_CODEC_ID_APAC,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Id::FTR => AV_CODEC_ID_FTR,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Id::WAVARC => AV_CODEC_ID_WAVARC,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Id::RKA => AV_CODEC_ID_RKA,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Id::VNULL => AV_CODEC_ID_VNULL,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Id::ANULL => AV_CODEC_ID_ANULL,
         }
     }
 }

--- a/src/codec/id.rs
+++ b/src/codec/id.rs
@@ -1233,6 +1233,7 @@ impl From<AVCodecID> for Id {
             AV_CODEC_ID_PHM => Id::PHM,
             #[cfg(feature = "ffmpeg_5_1")]
             AV_CODEC_ID_DFPWM => Id::DFPWM,
+            v => unimplemented!("{v:?} is not supported yet"),
         }
     }
 }

--- a/src/codec/threading.rs
+++ b/src/codec/threading.rs
@@ -5,6 +5,7 @@ use libc::c_int;
 pub struct Config {
     pub kind: Type,
     pub count: usize,
+    #[cfg(not(feature = "ffmpeg_6_0"))]
     pub safe: bool,
 }
 
@@ -23,6 +24,7 @@ impl Config {
         }
     }
 
+    #[cfg(not(feature = "ffmpeg_6_0"))]
     pub fn safe(value: bool) -> Self {
         Config {
             safe: value,
@@ -36,6 +38,7 @@ impl Default for Config {
         Config {
             kind: Type::None,
             count: 0,
+            #[cfg(not(feature = "ffmpeg_6_0"))]
             safe: false,
         }
     }

--- a/src/filter/filter.rs
+++ b/src/filter/filter.rs
@@ -47,7 +47,12 @@ impl Filter {
             if ptr.is_null() {
                 None
             } else {
-                Some(PadIter::new((*self.as_ptr()).inputs, (*self.as_ptr()).nb_inputs as isize))
+                #[cfg(not(feature = "ffmpeg_6_0"))]
+                let nb_inputs = avfilter_pad_count((*self.as_ptr()).inputs) as isize;
+                #[cfg(feature = "ffmpeg_6_0")]
+                let nb_inputs = (*self.as_ptr()).nb_inputs as isize;
+
+                Some(PadIter::new((*self.as_ptr()).inputs, nb_inputs))
             }
         }
     }
@@ -59,7 +64,12 @@ impl Filter {
             if ptr.is_null() {
                 None
             } else {
-                Some(PadIter::new((*self.as_ptr()).outputs, (*self.as_ptr()).nb_outputs as isize))
+                #[cfg(not(feature = "ffmpeg_6_0"))]
+                let nb_outputs = avfilter_pad_count((*self.as_ptr()).outputs) as isize;
+                #[cfg(feature = "ffmpeg_6_0")]
+                let nb_outputs = (*self.as_ptr()).nb_outputs as isize;
+
+                Some(PadIter::new((*self.as_ptr()).outputs, nb_outputs))
             }
         }
     }

--- a/src/filter/filter.rs
+++ b/src/filter/filter.rs
@@ -47,7 +47,7 @@ impl Filter {
             if ptr.is_null() {
                 None
             } else {
-                Some(PadIter::new((*self.as_ptr()).inputs))
+                Some(PadIter::new((*self.as_ptr()).inputs, (*self.as_ptr()).nb_inputs as isize))
             }
         }
     }
@@ -59,7 +59,7 @@ impl Filter {
             if ptr.is_null() {
                 None
             } else {
-                Some(PadIter::new((*self.as_ptr()).outputs))
+                Some(PadIter::new((*self.as_ptr()).outputs, (*self.as_ptr()).nb_outputs as isize))
             }
         }
     }
@@ -71,15 +71,17 @@ impl Filter {
 
 pub struct PadIter<'a> {
     ptr: *const AVFilterPad,
+    count: isize,
     cur: isize,
 
     _marker: PhantomData<&'a ()>,
 }
 
 impl<'a> PadIter<'a> {
-    pub fn new(ptr: *const AVFilterPad) -> Self {
+    pub fn new(ptr: *const AVFilterPad, count: isize) -> Self {
         PadIter {
             ptr,
+            count,
             cur: 0,
             _marker: PhantomData,
         }
@@ -91,7 +93,7 @@ impl<'a> Iterator for PadIter<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         unsafe {
-            if self.cur >= avfilter_pad_count(self.ptr) as isize {
+            if self.cur >= self.count {
                 return None;
             }
 

--- a/src/util/format/pixel.rs
+++ b/src/util/format/pixel.rs
@@ -742,6 +742,7 @@ impl From<AVPixelFormat> for Pixel {
             AV_PIX_FMT_RPI4_8 => Pixel::RPI4_8,
             #[cfg(feature = "rpi")]
             AV_PIX_FMT_RPI4_10 => Pixel::RPI4_10,
+            v => unimplemented!("{v:?} is not supported yet"),
         }
     }
 }

--- a/src/util/format/pixel.rs
+++ b/src/util/format/pixel.rs
@@ -368,6 +368,39 @@ pub enum Pixel {
     #[cfg(feature = "ffmpeg_5_0")]
     P416LE,
 
+    #[cfg(feature = "ffmpeg_6_0")]
+    VUYA,
+    #[cfg(feature = "ffmpeg_6_0")]
+    RGBAF16BE,
+    #[cfg(feature = "ffmpeg_6_0")]
+    RGBAF16LE,
+    #[cfg(feature = "ffmpeg_6_0")]
+    VUYX,
+    #[cfg(feature = "ffmpeg_6_0")]
+    P012LE,
+    #[cfg(feature = "ffmpeg_6_0")]
+    P012BE,
+    #[cfg(feature = "ffmpeg_6_0")]
+    Y212BE,
+    #[cfg(feature = "ffmpeg_6_0")]
+    Y212LE,
+    #[cfg(feature = "ffmpeg_6_0")]
+    XV30BE,
+    #[cfg(feature = "ffmpeg_6_0")]
+    XV30LE,
+    #[cfg(feature = "ffmpeg_6_0")]
+    XV36BE,
+    #[cfg(feature = "ffmpeg_6_0")]
+    XV36LE,
+    #[cfg(feature = "ffmpeg_6_0")]
+    RGBF32BE,
+    #[cfg(feature = "ffmpeg_6_0")]
+    RGBF32LE,
+    #[cfg(feature = "ffmpeg_6_0")]
+    RGBAF32BE,
+    #[cfg(feature = "ffmpeg_6_0")]
+    RGBAF32LE,
+
     #[cfg(feature = "rpi")]
     RPI,
     #[cfg(feature = "rpi")]
@@ -730,6 +763,39 @@ impl From<AVPixelFormat> for Pixel {
             #[cfg(feature = "ffmpeg_5_0")]
             AV_PIX_FMT_P416LE => Pixel::P416LE,
 
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_PIX_FMT_VUYA => Pixel::VUYA,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_PIX_FMT_RGBAF16BE => Pixel::RGBAF16BE,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_PIX_FMT_RGBAF16LE => Pixel::RGBAF16LE,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_PIX_FMT_VUYX => Pixel::VUYX,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_PIX_FMT_P012LE => Pixel::P012LE,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_PIX_FMT_P012BE => Pixel::P012BE,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_PIX_FMT_Y212BE => Pixel::Y212BE,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_PIX_FMT_Y212LE => Pixel::Y212LE,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_PIX_FMT_XV30BE => Pixel::XV30BE,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_PIX_FMT_XV30LE => Pixel::XV30LE,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_PIX_FMT_XV36BE => Pixel::XV36BE,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_PIX_FMT_XV36LE => Pixel::XV36LE,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_PIX_FMT_RGBF32BE => Pixel::RGBF32BE,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_PIX_FMT_RGBF32LE => Pixel::RGBF32LE,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_PIX_FMT_RGBAF32BE => Pixel::RGBAF32BE,
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_PIX_FMT_RGBAF32LE => Pixel::RGBAF32LE,
+
             #[cfg(feature = "rpi")]
             AV_PIX_FMT_RPI => Pixel::RPI,
             #[cfg(feature = "rpi")]
@@ -742,7 +808,6 @@ impl From<AVPixelFormat> for Pixel {
             AV_PIX_FMT_RPI4_8 => Pixel::RPI4_8,
             #[cfg(feature = "rpi")]
             AV_PIX_FMT_RPI4_10 => Pixel::RPI4_10,
-            v => { eprintln!("{v:?} is not supported yet"); Pixel::None },
         }
     }
 }
@@ -1110,6 +1175,39 @@ impl From<Pixel> for AVPixelFormat {
             Pixel::P416BE => AV_PIX_FMT_P416BE,
             #[cfg(feature = "ffmpeg_5_0")]
             Pixel::P416LE => AV_PIX_FMT_P416LE,
+
+            #[cfg(feature = "ffmpeg_6_0")]
+            Pixel::VUYA => AV_PIX_FMT_VUYA,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Pixel::RGBAF16BE => AV_PIX_FMT_RGBAF16BE,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Pixel::RGBAF16LE => AV_PIX_FMT_RGBAF16LE,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Pixel::VUYX => AV_PIX_FMT_VUYX,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Pixel::P012LE => AV_PIX_FMT_P012LE,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Pixel::P012BE => AV_PIX_FMT_P012BE,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Pixel::Y212BE => AV_PIX_FMT_Y212BE,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Pixel::Y212LE => AV_PIX_FMT_Y212LE,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Pixel::XV30BE => AV_PIX_FMT_XV30BE,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Pixel::XV30LE => AV_PIX_FMT_XV30LE,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Pixel::XV36BE => AV_PIX_FMT_XV36BE,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Pixel::XV36LE => AV_PIX_FMT_XV36LE,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Pixel::RGBF32BE => AV_PIX_FMT_RGBF32BE,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Pixel::RGBF32LE => AV_PIX_FMT_RGBF32LE,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Pixel::RGBAF32BE => AV_PIX_FMT_RGBAF32BE,
+            #[cfg(feature = "ffmpeg_6_0")]
+            Pixel::RGBAF32LE => AV_PIX_FMT_RGBAF32LE,
 
             #[cfg(feature = "rpi")]
             Pixel::RPI => AV_PIX_FMT_RPI,

--- a/src/util/format/pixel.rs
+++ b/src/util/format/pixel.rs
@@ -742,7 +742,7 @@ impl From<AVPixelFormat> for Pixel {
             AV_PIX_FMT_RPI4_8 => Pixel::RPI4_8,
             #[cfg(feature = "rpi")]
             AV_PIX_FMT_RPI4_10 => Pixel::RPI4_10,
-            v => unimplemented!("{v:?} is not supported yet"),
+            v => { eprintln!("{v:?} is not supported yet"); Pixel::None },
         }
     }
 }

--- a/src/util/frame/side_data.rs
+++ b/src/util/frame/side_data.rs
@@ -58,6 +58,9 @@ pub enum Type {
 
     #[cfg(feature = "ffmpeg_5_1")]
     DYNAMIC_HDR_VIVID,
+
+    #[cfg(feature = "ffmpeg_6_0")]
+    AMBIENT_VIEWING_ENVIRONMENT,
 }
 
 impl Type {
@@ -120,6 +123,9 @@ impl From<AVFrameSideDataType> for Type {
 
             #[cfg(feature = "ffmpeg_5_1")]
             AV_FRAME_DATA_DYNAMIC_HDR_VIVID => Type::DYNAMIC_HDR_VIVID,
+
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_FRAME_DATA_AMBIENT_VIEWING_ENVIRONMENT => Type::AMBIENT_VIEWING_ENVIRONMENT,
         }
     }
 }
@@ -175,6 +181,9 @@ impl From<Type> for AVFrameSideDataType {
 
             #[cfg(feature = "ffmpeg_5_1")]
             Type::DYNAMIC_HDR_VIVID => AV_FRAME_DATA_DYNAMIC_HDR_VIVID,
+
+            #[cfg(feature = "ffmpeg_6_0")]
+            Type::AMBIENT_VIEWING_ENVIRONMENT => AV_FRAME_DATA_AMBIENT_VIEWING_ENVIRONMENT,
         }
     }
 }


### PR DESCRIPTION
Even though 6.0 is not officially released yet, the API changes are frozen and releases/6.0 is branched.
This PR adds support for the 6.0 branch

Depends on https://github.com/zmwangx/rust-ffmpeg-sys/pull/50