### PR TITLE
Add patch to support wasm32-wasi target.

### DIFF
--- a/src/util/error.rs
+++ b/src/util/error.rs
@@ -9,7 +9,7 @@ use libc::{c_char, c_int};
 
 // Export POSIX error codes so that users can do something like
 //
-//   if error == (Error::Other { errno: EAGAIN }) {
+//   if error == (Error::Other { c_errno: EAGAIN }) {
 //       ...
 //   }
 pub use libc::{
@@ -22,7 +22,7 @@ pub use libc::{
     EOPNOTSUPP, EOVERFLOW, EOWNERDEAD, EPERM, EPIPE, EPROTO, EPROTONOSUPPORT, EPROTOTYPE, ERANGE,
     EROFS, ESPIPE, ESRCH, ETIMEDOUT, ETXTBSY, EWOULDBLOCK, EXDEV,
 };
-#[cfg(not(all(target_arch = "wasm32", target_os = "wasi")))]
+#[cfg(not(any(target_os = "freebsd", target_os = "wasi")))]
 pub use libc::{ENODATA, ENOSR, ENOSTR, ETIME};
 
 #[derive(Copy, Clone, PartialEq, Eq)]
@@ -358,7 +358,10 @@ mod tests {
             Into::<c_int>::into(Error::from(AVERROR(EAGAIN))),
             AVERROR(EAGAIN)
         );
-        assert_eq!(Error::from(AVERROR(EAGAIN)), Error::Other { errno: EAGAIN });
+        assert_eq!(
+            Error::from(AVERROR(EAGAIN)),
+            Error::Other { c_errno: EAGAIN }
+        );
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]


### PR DESCRIPTION
## changes

1. libc has no ```ENODATA```, ```ENOSR```, ```ENOSTR```, ```ETIME``` for ```wasm32-wasi``` target, so I change these into conditional compile.
2. In ```wasm32-wasi``` target, ```errno``` is a static variable in ```errno.h```,  the member name cannot be named the same as a static, so I change ```errno``` to ```c_errno```.

The examples which use ```ffmpeg-next``` and compile to ```wasm32-wasi``` target can be found at https://github.com/yanghaku/ffmpeg-wasm32-wasi.
