### PR TITLE
Fix packet read an error which is not EOF and the PacketIter will be blocked

### DIFF
--- a/src/format/context/input.rs
+++ b/src/format/context/input.rs
@@ -164,19 +164,14 @@ impl<'a> Iterator for PacketIter<'a> {
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
         let mut packet = Packet::empty();
 
-        loop {
-            match packet.read(self.context) {
-                Ok(..) => unsafe {
-                    return Some((
-                        Stream::wrap(mem::transmute_copy(&self.context), packet.stream()),
-                        packet,
-                    ));
-                },
-
-                Err(Error::Eof) => return None,
-
-                Err(..) => (),
-            }
+        match packet.read(self.context) {
+            Ok(..) => unsafe {
+                Some((
+                    Stream::wrap(mem::transmute_copy(&self.context), packet.stream()),
+                    packet,
+                ))
+            },
+            Err(..) => None,
         }
     }
 }


### PR DESCRIPTION
When I get the packets data through the function Input.packets(), and the source stream is closed without send EOF. the PacketIter will be blocked.