### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 - Introduce conditional compilation flags to preserve functions that are
   removed from ffmpeg 5.0 and onwards.
-- Fix examples so they are using the ffmpeg-sanctionned way of doing
+- Fix examples so they are using the ffmpeg-sanctioned way of doing
   things. More specifically, AVStream.codec has been removed, and the
   correct way of getting the codec from a stream is to use
   Context::from_parameters(stream.parameters()) and then that context's

--- a/src/codec/decoder/check.rs
+++ b/src/codec/decoder/check.rs
@@ -4,7 +4,7 @@ use libc::c_int;
 bitflags! {
     pub struct Check: c_int {
         const CRC      = AV_EF_CRCCHECK;
-        const BISTREAM = AV_EF_BITSTREAM;
+        const BITSTREAM = AV_EF_BITSTREAM;
         const BUFFER   = AV_EF_BUFFER;
         const EXPLODE  = AV_EF_EXPLODE;
 

--- a/src/format/chapter/chapter.rs
+++ b/src/format/chapter/chapter.rs
@@ -4,7 +4,7 @@ use {DictionaryRef, Rational};
 use format::context::common::Context;
 
 // WARNING: index refers to the offset in the chapters array (starting from 0)
-// it is not necessarly equal to the id (which may start at 1)
+// it is not necessarily equal to the id (which may start at 1)
 pub struct Chapter<'a> {
     context: &'a Context,
     index: usize,

--- a/src/format/chapter/chapter_mut.rs
+++ b/src/format/chapter/chapter_mut.rs
@@ -7,7 +7,7 @@ use format::context::common::Context;
 use {Dictionary, DictionaryMut, Rational};
 
 // WARNING: index refers to the offset in the chapters array (starting from 0)
-// it is not necessarly equal to the id (which may start at 1)
+// it is not necessarily equal to the id (which may start at 1)
 pub struct ChapterMut<'a> {
     context: &'a mut Context,
     index: usize,


### PR DESCRIPTION
Found via `typos --format brief`