### PR TITLE
Enable creation of codec context for specific codec + codec: add new_with_codec method to codec context

### DIFF
--- a/src/codec/context.rs
+++ b/src/codec/context.rs
@@ -40,6 +40,15 @@ impl Context {
             }
         }
     }
+    
+    pub fn new_with_codec(codec: Codec) -> Self {
+        unsafe {
+            Context {
+                ptr: avcodec_alloc_context3(codec.as_ptr()),
+                owner: None,
+            }
+        }
+    }
 
     pub fn from_parameters<P: Into<Parameters>>(parameters: P) -> Result<Self, Error> {
         let parameters = parameters.into();

--- a/src/codec/decoder/decoder.rs
+++ b/src/codec/decoder/decoder.rs
@@ -52,23 +52,27 @@ impl Decoder {
             }
         }
     }
-
+    
     pub fn video(self) -> Result<Video, Error> {
-        if let Some(codec) = super::find(self.id()) {
+        if let Some(codec) = self.0.codec() {
+            self.open_as(codec).and_then(|o| o.video())
+        } else if let Some(codec) = super::find(self.id()) {
             self.open_as(codec).and_then(|o| o.video())
         } else {
             Err(Error::DecoderNotFound)
         }
     }
-
+    
     pub fn audio(self) -> Result<Audio, Error> {
-        if let Some(codec) = super::find(self.id()) {
+        if let Some(codec) = self.0.codec() {
+            self.open_as(codec).and_then(|o| o.audio())
+        } else if let Some(codec) = super::find(self.id()) {
             self.open_as(codec).and_then(|o| o.audio())
         } else {
             Err(Error::DecoderNotFound)
         }
     }
-
+    
     pub fn subtitle(self) -> Result<Subtitle, Error> {
         if let Some(codec) = super::find(self.id()) {
             self.open_as(codec).and_then(|o| o.subtitle())


### PR DESCRIPTION
combine https://github.com/zmwangx/rust-ffmpeg/pull/51 and https://github.com/zmwangx/rust-ffmpeg/pull/129 on the latest master