### PR TITLE
Implement Display for Id

### DIFF
--- a/src/codec/id.rs
+++ b/src/codec/id.rs
@@ -1945,9 +1945,6 @@ impl From<Id> for AVCodecID {
 
 impl fmt::Display for Id {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        let name = unsafe {
-            from_utf8_unchecked(CStr::from_ptr(avcodec_get_name((*self).into())).to_bytes())
-        };
-        write!(f, "{}", name)
+        write!(f, "{}", self.name())
     }
 }

--- a/src/codec/id.rs
+++ b/src/codec/id.rs
@@ -1,4 +1,5 @@
 use std::ffi::CStr;
+use std::fmt;
 use std::str::from_utf8_unchecked;
 
 use ffi::AVCodecID::*;
@@ -1939,5 +1940,14 @@ impl From<Id> for AVCodecID {
             #[cfg(feature = "ffmpeg_6_0")]
             Id::ANULL => AV_CODEC_ID_ANULL,
         }
+    }
+}
+
+impl fmt::Display for Id {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        let name = unsafe {
+            from_utf8_unchecked(CStr::from_ptr(avcodec_get_name((*self).into())).to_bytes())
+        };
+        write!(f, "{}", name)
     }
 }


### PR DESCRIPTION
This change implements the `std::fmt::Display` trait for `ffmpeg_next::codec:::id::Id`

EDIT:
Escape markdown emotes