### PR TITLE
Implement Display for Id

### DIFF
--- a/src/codec/id.rs
+++ b/src/codec/id.rs
@@ -1,4 +1,5 @@
 use std::ffi::CStr;
+use std::fmt;
 use std::str::from_utf8_unchecked;
 
 use ffi::AVCodecID::*;
@@ -1939,5 +1940,11 @@ impl From<Id> for AVCodecID {
             #[cfg(feature = "ffmpeg_6_0")]
             Id::ANULL => AV_CODEC_ID_ANULL,
         }
+    }
+}
+
+impl fmt::Display for Id {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "{}", self.name())
     }
 }


### PR DESCRIPTION
This change implements the `std::fmt::Display` trait for `ffmpeg_next::codec:::id::Id`