### PR TITLE
impl Send for software::scaling::Context

### DIFF
--- a/src/software/scaling/context.rs
+++ b/src/software/scaling/context.rs
@@ -20,6 +20,8 @@ pub struct Context {
     output: Definition,
 }
 
+unsafe impl Send for Context {}
+
 impl Context {
     #[inline(always)]
     pub unsafe fn as_ptr(&self) -> *const SwsContext {


### PR DESCRIPTION
as someone once said in a [previous PR](https://github.com/zmwangx/rust-ffmpeg/pull/85) (not sure why it was closed),
>AFAICT the scaling Context should impl Send just like the [resampler](https://docs.rs/ffmpeg-next/latest/src/ffmpeg_next/software/resampling/context.rs.html#25)