### PR TITLE
fix graph input/output linked list insertion

### DIFF
--- a/src/filter/graph.rs
+++ b/src/filter/graph.rs
@@ -161,7 +161,11 @@ impl<'a> Parser<'a> {
             if self.inputs.is_null() {
                 self.inputs = input;
             } else {
-                (*self.inputs).next = input;
+                let mut cur = self.inputs;
+                while !(*cur).next.is_null() {
+                    cur = (*cur).next
+                }
+                (*cur).next = input;
             }
         }
 
@@ -187,7 +191,11 @@ impl<'a> Parser<'a> {
             if self.outputs.is_null() {
                 self.outputs = output;
             } else {
-                (*self.outputs).next = output;
+                let mut cur = self.outputs;
+                while !(*cur).next.is_null() {
+                    cur = (*cur).next
+                }
+                (*cur).next = output;
             }
         }
 


### PR DESCRIPTION
This fixes a bug where adding multiple inputs or outputs to a graph causes at most two of them two be inserted. The result is errors such as

Input pad "default" with type audio of the filter instance "out2" of abuffersink not connected to any source

when calling validate. The fix walks the linked list and appends the new node to the end. This operation is linear, with the assumption that inputs and outputs are small and building the graph happens infrequently.

I added a test which reproduces the issue for both inputs and outputs.