### PR TITLE
audio linesize[0]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
       matrix:
         include:
           - ffmpeg_version: latest
-            ffmpeg_download_url: https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full-shared.7z
+            ffmpeg_download_url: https://www.gyan.dev/ffmpeg/builds/ffmpeg-6.0-full_build-shared.7z
       fail-fast: false
     env:
       FFMPEG_DOWNLOAD_URL: ${{ matrix.ffmpeg_download_url }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,5 +113,5 @@ version  = "0.23"
 optional = true
 
 [dependencies.ffmpeg-sys-next]
-version = "6.0.1"
+version = "=6.0.1"
 default-features = false

--- a/src/util/frame/audio.rs
+++ b/src/util/frame/audio.rs
@@ -169,7 +169,7 @@ impl Audio {
         unsafe {
             slice::from_raw_parts(
                 (*self.as_ptr()).data[index],
-                (*self.as_ptr()).linesize[index] as usize,
+                (*self.as_ptr()).linesize[0] as usize,
             )
         }
     }
@@ -183,7 +183,7 @@ impl Audio {
         unsafe {
             slice::from_raw_parts_mut(
                 (*self.as_mut_ptr()).data[index],
-                (*self.as_ptr()).linesize[index] as usize,
+                (*self.as_ptr()).linesize[0] as usize,
             )
         }
     }


### PR DESCRIPTION
audio frames currently try to read the linesize entry using the plane index. the comment on linesize says `For audio, only linesize[0] may be set. For planar audio, each channel plane must be the same size.`

-> always use linesize[0] in audio