### PR TITLE
Improve time_base support & additions for ffmpeg 5-6

### DIFF
--- a/examples/transcode-audio.rs
+++ b/examples/transcode-audio.rs
@@ -62,7 +62,7 @@ struct Transcoder {
     out_time_base: ffmpeg::Rational,
 }
 
-fn transcoder<P: AsRef<Path>>(
+fn transcoder<P: AsRef<Path> + ?Sized>(
     ictx: &mut format::context::Input,
     octx: &mut format::context::Output,
     path: &P,

--- a/src/codec/codec.rs
+++ b/src/codec/codec.rs
@@ -7,23 +7,19 @@ use {media, Error};
 
 #[derive(PartialEq, Eq, Copy, Clone)]
 pub struct Codec {
-    ptr: *mut AVCodec,
+    ptr: *const AVCodec,
 }
 
 unsafe impl Send for Codec {}
 unsafe impl Sync for Codec {}
 
 impl Codec {
-    pub unsafe fn wrap(ptr: *mut AVCodec) -> Self {
+    pub unsafe fn wrap(ptr: *const AVCodec) -> Self {
         Codec { ptr }
     }
 
     pub unsafe fn as_ptr(&self) -> *const AVCodec {
         self.ptr as *const _
-    }
-
-    pub unsafe fn as_mut_ptr(&mut self) -> *mut AVCodec {
-        self.ptr
     }
 }
 

--- a/src/codec/context.rs
+++ b/src/codec/context.rs
@@ -41,6 +41,15 @@ impl Context {
         }
     }
 
+    pub fn new_with_codec(codec: Codec) -> Self {
+        unsafe {
+            Context {
+                ptr: avcodec_alloc_context3(codec.as_ptr()),
+                owner: None,
+            }
+        }
+    }
+
     pub fn from_parameters<P: Into<Parameters>>(parameters: P) -> Result<Self, Error> {
         let parameters = parameters.into();
         let mut context = Self::new();

--- a/src/codec/context.rs
+++ b/src/codec/context.rs
@@ -8,7 +8,7 @@ use super::{threading, Compliance, Debug, Flags, Id, Parameters};
 use ffi::*;
 use libc::c_int;
 use media;
-use {Codec, Error};
+use {Codec, Error, Rational};
 
 pub struct Context {
     ptr: *mut AVCodecContext,
@@ -135,6 +135,31 @@ impl Context {
             match avcodec_parameters_to_context(self.as_mut_ptr(), parameters.as_ptr()) {
                 e if e < 0 => Err(Error::from(e)),
                 _ => Ok(()),
+            }
+        }
+    }
+
+    pub fn time_base(&self) -> Rational {
+        unsafe { Rational::from((*self.as_ptr()).time_base) }
+    }
+
+    pub fn set_time_base<R: Into<Rational>>(&mut self, value: R) {
+        unsafe {
+            (*self.as_mut_ptr()).time_base = value.into().into();
+        }
+    }
+
+    pub fn frame_rate(&self) -> Rational {
+        unsafe { Rational::from((*self.as_ptr()).framerate) }
+    }
+
+    pub fn set_frame_rate<R: Into<Rational>>(&mut self, value: Option<R>) {
+        unsafe {
+            if let Some(value) = value {
+                (*self.as_mut_ptr()).framerate = value.into().into();
+            } else {
+                (*self.as_mut_ptr()).framerate.num = 0;
+                (*self.as_mut_ptr()).framerate.den = 1;
             }
         }
     }

--- a/src/codec/decoder/decoder.rs
+++ b/src/codec/decoder/decoder.rs
@@ -107,8 +107,14 @@ impl Decoder {
         }
     }
 
-    pub fn time_base(&self) -> Rational {
-        unsafe { Rational::from((*self.as_ptr()).time_base) }
+    pub fn packet_time_base(&self) -> Rational {
+        unsafe { Rational::from((*self.as_ptr()).pkt_timebase) }
+    }
+
+    pub fn set_packet_time_base<R: Into<Rational>>(&mut self, value: R) {
+        unsafe {
+            (*self.as_mut_ptr()).pkt_timebase = value.into().into();
+        }
     }
 }
 

--- a/src/codec/encoder/encoder.rs
+++ b/src/codec/encoder/encoder.rs
@@ -6,7 +6,7 @@ use libc::c_int;
 
 use super::{audio, subtitle, video};
 use codec::Context;
-use {media, packet, Error, Frame, Rational};
+use {media, packet, Error, Frame};
 
 pub struct Encoder(pub Context);
 
@@ -113,23 +113,6 @@ impl Encoder {
                 (*self.as_mut_ptr()).compression_level = value as c_int;
             } else {
                 (*self.as_mut_ptr()).compression_level = -1;
-            }
-        }
-    }
-
-    pub fn set_time_base<R: Into<Rational>>(&mut self, value: R) {
-        unsafe {
-            (*self.as_mut_ptr()).time_base = value.into().into();
-        }
-    }
-
-    pub fn set_frame_rate<R: Into<Rational>>(&mut self, value: Option<R>) {
-        unsafe {
-            if let Some(value) = value {
-                (*self.as_mut_ptr()).framerate = value.into().into();
-            } else {
-                (*self.as_mut_ptr()).framerate.num = 0;
-                (*self.as_mut_ptr()).framerate.den = 1;
             }
         }
     }

--- a/src/codec/packet/packet.rs
+++ b/src/codec/packet/packet.rs
@@ -144,6 +144,18 @@ impl Packet {
     }
 
     #[inline]
+    #[cfg(feature = "ffmpeg_5_0")]
+    pub fn time_base(&self) -> Rational {
+        self.0.time_base.into()
+    }
+
+    #[inline]
+    #[cfg(feature = "ffmpeg_5_0")]
+    pub fn set_time_base(&mut self, value: Rational) {
+        self.0.time_base = value.into();
+    }
+
+    #[inline]
     pub fn size(&self) -> usize {
         self.0.size as usize
     }

--- a/src/filter/context/sink.rs
+++ b/src/filter/context/sink.rs
@@ -1,7 +1,7 @@
 use super::Context;
 use ffi::*;
 use libc::c_int;
-use {Error, Frame};
+use {Error, Frame, Rational};
 
 pub struct Sink<'a> {
     ctx: &'a mut Context<'a>,
@@ -40,5 +40,9 @@ impl<'a> Sink<'a> {
         unsafe {
             av_buffersink_set_frame_size(self.ctx.as_mut_ptr(), value);
         }
+    }
+
+    pub fn time_base(&self) -> Rational {
+        unsafe { av_buffersink_get_time_base(self.ctx.as_ptr()) }.into()
     }
 }

--- a/src/format/format/output.rs
+++ b/src/format/format/output.rs
@@ -63,7 +63,7 @@ impl Output {
         }
     }
 
-    pub fn codec<P: AsRef<Path>>(&self, path: &P, kind: media::Type) -> codec::Id {
+    pub fn codec<P: AsRef<Path> + ?Sized>(&self, path: &P, kind: media::Type) -> codec::Id {
         // XXX: use to_cstring when stable
         let path = CString::new(path.as_ref().as_os_str().to_str().unwrap()).unwrap();
 

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -58,12 +58,12 @@ pub fn license() -> &'static str {
 }
 
 // XXX: use to_cstring when stable
-fn from_path<P: AsRef<Path>>(path: &P) -> CString {
+fn from_path<P: AsRef<Path> + ?Sized>(path: &P) -> CString {
     CString::new(path.as_ref().as_os_str().to_str().unwrap()).unwrap()
 }
 
 // NOTE: this will be better with specialization or anonymous return types
-pub fn open<P: AsRef<Path>>(path: &P, format: &Format) -> Result<Context, Error> {
+pub fn open<P: AsRef<Path> + ?Sized>(path: &P, format: &Format) -> Result<Context, Error> {
     unsafe {
         let mut ps = ptr::null_mut();
         let path = from_path(path);
@@ -100,7 +100,7 @@ pub fn open<P: AsRef<Path>>(path: &P, format: &Format) -> Result<Context, Error>
     }
 }
 
-pub fn open_with<P: AsRef<Path>>(
+pub fn open_with<P: AsRef<Path> + ?Sized>(
     path: &P,
     format: &Format,
     options: Dictionary,
@@ -148,7 +148,7 @@ pub fn open_with<P: AsRef<Path>>(
     }
 }
 
-pub fn input<P: AsRef<Path>>(path: &P) -> Result<context::Input, Error> {
+pub fn input<P: AsRef<Path> + ?Sized>(path: &P) -> Result<context::Input, Error> {
     unsafe {
         let mut ps = ptr::null_mut();
         let path = from_path(path);
@@ -167,7 +167,7 @@ pub fn input<P: AsRef<Path>>(path: &P) -> Result<context::Input, Error> {
     }
 }
 
-pub fn input_with_dictionary<P: AsRef<Path>>(
+pub fn input_with_dictionary<P: AsRef<Path> + ?Sized>(
     path: &P,
     options: Dictionary,
 ) -> Result<context::Input, Error> {
@@ -193,7 +193,7 @@ pub fn input_with_dictionary<P: AsRef<Path>>(
     }
 }
 
-pub fn input_with_interrupt<P: AsRef<Path>, F>(
+pub fn input_with_interrupt<P: AsRef<Path> + ?Sized, F>(
     path: &P,
     closure: F,
 ) -> Result<context::Input, Error>
@@ -219,7 +219,7 @@ where
     }
 }
 
-pub fn output<P: AsRef<Path>>(path: &P) -> Result<context::Output, Error> {
+pub fn output<P: AsRef<Path> + ?Sized>(path: &P) -> Result<context::Output, Error> {
     unsafe {
         let mut ps = ptr::null_mut();
         let path = from_path(path);
@@ -235,7 +235,7 @@ pub fn output<P: AsRef<Path>>(path: &P) -> Result<context::Output, Error> {
     }
 }
 
-pub fn output_with<P: AsRef<Path>>(
+pub fn output_with<P: AsRef<Path> + ?Sized>(
     path: &P,
     options: Dictionary,
 ) -> Result<context::Output, Error> {
@@ -267,7 +267,10 @@ pub fn output_with<P: AsRef<Path>>(
     }
 }
 
-pub fn output_as<P: AsRef<Path>>(path: &P, format: &str) -> Result<context::Output, Error> {
+pub fn output_as<P: AsRef<Path> + ?Sized>(
+    path: &P,
+    format: &str,
+) -> Result<context::Output, Error> {
     unsafe {
         let mut ps = ptr::null_mut();
         let path = from_path(path);
@@ -289,7 +292,7 @@ pub fn output_as<P: AsRef<Path>>(path: &P, format: &str) -> Result<context::Outp
     }
 }
 
-pub fn output_as_with<P: AsRef<Path>>(
+pub fn output_as_with<P: AsRef<Path> + ?Sized>(
     path: &P,
     format: &str,
     options: Dictionary,


### PR DESCRIPTION
This adds various accessors and setters that are useful when building a timebase-aware transcoding pipeline.

Each commit has details on the exact changes. Happy to drop or rework any of them.

Important changes for ffmpeg 5-6 support:
- `Context::new_with_codec` (see also #51, #129, #149). This is important to initialize a context with the default values from a Codec.
- `Output::add_stream_with`: Calls `avcodec_parameters_from_context`, important for setting the codec parameters for a Stream. (See #118)