### PR TITLE
Implement wrapper for sws_getCoefficients()

### DIFF
--- a/src/software/scaling/color_space.rs
+++ b/src/software/scaling/color_space.rs
@@ -11,6 +11,7 @@ pub enum ColorSpace {
     ITU624,
     SMPTE170M,
     SMPTE240M,
+    BT2020,
 }
 
 impl From<c_int> for ColorSpace {
@@ -18,9 +19,10 @@ impl From<c_int> for ColorSpace {
         match value {
             SWS_CS_ITU709 => ColorSpace::ITU709,
             SWS_CS_FCC => ColorSpace::FCC,
+            // Default is same as ITU601
             SWS_CS_DEFAULT => ColorSpace::Default,
             SWS_CS_SMPTE240M => ColorSpace::SMPTE240M,
-
+            SWS_CS_BT2020 => ColorSpace::BT2020,
             _ => ColorSpace::Default,
         }
     }
@@ -36,6 +38,7 @@ impl From<ColorSpace> for c_int {
             ColorSpace::ITU624 => SWS_CS_ITU624,
             ColorSpace::SMPTE170M => SWS_CS_SMPTE170M,
             ColorSpace::SMPTE240M => SWS_CS_SMPTE240M,
+            ColorSpace::BT2020 => SWS_CS_BT2020,
         }
     }
 }

--- a/src/software/scaling/context.rs
+++ b/src/software/scaling/context.rs
@@ -82,10 +82,9 @@ impl Context {
 
     pub fn set_colorspace_details(
         &mut self,
-        space: ColorSpace,
+        input_yuv_space: color::Space,
         src_range: color::Range,
         dst_range: color::Range,
-        input_yuv_space: color::Space,
         brightness: i32,
         contrast: i32,
         saturation: i32,

--- a/src/software/scaling/context.rs
+++ b/src/software/scaling/context.rs
@@ -82,7 +82,7 @@ impl Context {
 
     pub fn set_colorspace_details(
         &mut self,
-        input_yuv_space: color::Space,
+        input_space: color::Space,
         src_range: color::Range,
         dst_range: color::Range,
         brightness: i32,
@@ -90,7 +90,7 @@ impl Context {
         saturation: i32,
     ) {
         unsafe {
-            let input_color_space_int = match input_yuv_space {
+            let input_color_space_int = match input_space {
                 color::Space::BT709 => ColorSpace::ITU709,
                 color::Space::BT2020CL => ColorSpace::BT2020,
                 color::Space::BT2020NCL => ColorSpace::BT2020,

--- a/src/software/scaling/context.rs
+++ b/src/software/scaling/context.rs
@@ -1,6 +1,8 @@
 use std::ptr;
 
-use super::Flags;
+use crate::color;
+
+use super::{ColorSpace, Flags};
 use ffi::*;
 use libc::c_int;
 use util::format;
@@ -41,6 +43,8 @@ impl Context {
         dst_w: u32,
         dst_h: u32,
         flags: Flags,
+        color_space: color::Space,
+        color_range: color::Range,
     ) -> Result<Self, Error> {
         unsafe {
             let ptr = sws_getContext(
@@ -75,6 +79,52 @@ impl Context {
             } else {
                 Err(Error::InvalidData)
             }
+        }
+    }
+
+    pub fn set_colorspace_details(
+        &mut self,
+        space: ColorSpace,
+        src_range: color::Range,
+        dst_range: color::Range,
+        input_yuv_space: color::Space,
+        brightness: i32,
+        contrast: i32,
+        saturation: i32,
+    ) {
+        unsafe {
+            let input_color_space_int = match input_yuv_space {
+                color::Space::BT709 => ColorSpace::ITU709,
+                color::Space::BT2020CL => ColorSpace::BT2020,
+                color::Space::BT2020NCL => ColorSpace::BT2020,
+                _ => ColorSpace::ITU601,
+            };
+            let coefficients: *const i32 = sws_getCoefficients(input_color_space_int.into());
+
+            // 0 means limited range (16-235), 1 means full range (0-255)
+            let src_range_value = match src_range {
+                color::Range::MPEG => 0,
+                color::Range::JPEG => 1,
+                color::Range::Unspecified => 1,
+            };
+            // 0 means limited range, 1 means full range
+            // For an RGB image, we want full range, for YUV, most of the time we want limited range
+            let dst_range_value = match dst_range {
+                color::Range::MPEG => 0,
+                color::Range::JPEG => 1,
+                color::Range::Unspecified => 1,
+            };
+
+            sws_setColorspaceDetails(
+                self.as_mut_ptr(),
+                coefficients,
+                src_range_value,
+                coefficients,
+                dst_range_value,
+                brightness,
+                contrast,
+                saturation,
+            );
         }
     }
 

--- a/src/software/scaling/context.rs
+++ b/src/software/scaling/context.rs
@@ -1,5 +1,7 @@
 use std::ptr;
 
+use crate::color;
+
 use super::{ColorSpace, Flags};
 use ffi::*;
 use libc::c_int;
@@ -41,8 +43,6 @@ impl Context {
         dst_w: u32,
         dst_h: u32,
         flags: Flags,
-        color_space: color::Space,
-        color_range: color::Range,
     ) -> Result<Self, Error> {
         unsafe {
             let ptr = sws_getContext(

--- a/src/software/scaling/context.rs
+++ b/src/software/scaling/context.rs
@@ -1,7 +1,5 @@
 use std::ptr;
 
-use crate::color;
-
 use super::{ColorSpace, Flags};
 use ffi::*;
 use libc::c_int;


### PR DESCRIPTION
Added new set_colorspace_details method for `Context` (swscaler).

By default, you can use sws_scale, but it by default assumes the default colorspace, which I understand to be BT.601. 
So if a video with a difference colorspace (BT.709 or BT.2020) is being input, then the colors shifts.

Using this function, you can control it!

For those curious, here is how I intend to use this to convert frames to RGB:

1. Call `let context = Context::get()`
2. Call `context.set_colorspace_details`
	1. `input_space`: Pass the value of `video.color_space()`
	2. `src_range`: Pass the value of `video.color_range()` 
	3. `dst_range`: In my case, I want to convert it to RGB, so I want full range, therefore I pass `color::Range::JPEG`
	4. `brightness`, `contrast`, `saturation`: I set all of those to `0` to make no correction


I have no experience, I just read https://www.canva.dev/blog/engineering/a-journey-through-colour-space-with-ffmpeg/. If you can, please review carefully.