### PR TITLE
Add support for FFmpeg 7.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Check format
         run: |
           cargo fmt -- --check
-  # Added because there is no ffmpeg7.0 docker image here yet
+  # Added only because there is no ffmpeg7.0 docker image here yet
   # https://github.com/jrottenberg/ffmpeg
   build-test-lint-7-0:
     name: FFmpeg 7.0 - build, test and lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Check format
         run: |
           cargo fmt -- --check
-  # Added only because there is no ffmpeg7.0 docker image here yet
+  # Added because there is no ffmpeg7.0 docker image here yet
   # https://github.com/jrottenberg/ffmpeg
   build-test-lint-7-0:
     name: FFmpeg 7.0 - build, test and lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
     strategy:
       fail-fast: false
     env:
-      FFMPEG_DIR: /home/runner/work/rust-ffmpeg-sys/rust-ffmpeg-sys/ffmpeg-7.0-linux-clang-default
+      FFMPEG_DIR: /home/runner/work/rust-ffmpeg/rust-ffmpeg/ffmpeg-7.0-linux-clang-default
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     container: jrottenberg/ffmpeg:${{ matrix.ffmpeg_version }}-ubuntu
     strategy:
       matrix:
-        ffmpeg_version: ["3.4", "4.0", "4.1", "4.2", "4.3", "4.4", "5.0", "5.1", "6.0"]
+        ffmpeg_version: ["3.4", "4.0", "4.1", "4.2", "4.3", "4.4", "5.0", "5.1", "6.0", "6.1"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
@@ -106,22 +106,23 @@ jobs:
       - name: Check format
         run: |
           cargo fmt -- --check
-  # Added only because there is no ffmpeg6.1 docker image here yet
+  # Added only because there is no ffmpeg7.0 docker image here yet
   # https://github.com/jrottenberg/ffmpeg
-  build-test-lint-latest:
-    name: FFmpeg Latest - build, test and lint
+  build-test-lint-7-0:
+    name: FFmpeg 7.0 - build, test and lint
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+    env:
+      FFMPEG_DIR: /home/runner/work/rust-ffmpeg-sys/rust-ffmpeg-sys/ffmpeg-7.0-linux-clang-default
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt install -y software-properties-common
-          sudo add-apt-repository ppa:ubuntuhandbook1/ffmpeg6
-          sudo apt update
-          sudo apt install -y --no-install-recommends clang curl pkg-config ffmpeg libavutil-dev libavcodec-dev libavformat-dev libavfilter-dev libavfilter-dev libavdevice-dev libswresample-dev
+          sudo apt install -y --no-install-recommends clang curl pkg-config xz-utils
+          curl -L https://sourceforge.net/projects/avbuild/files/linux/ffmpeg-7.0-linux-clang-default.tar.xz/download -o ffmpeg.tar.xz
+          tar -xf ffmpeg.tar.xz
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt install -y --no-install-recommends clang curl pkg-config xz-utils
+          sudo apt install -y --no-install-recommends clang curl pkg-config xz-utils libxv-dev
           curl -L https://sourceforge.net/projects/avbuild/files/linux/ffmpeg-7.0-linux-clang-default.tar.xz/download -o ffmpeg.tar.xz
           tar -xf ffmpeg.tar.xz
       - name: Set up Rust

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,4 +115,3 @@ optional = true
 [dependencies.ffmpeg-sys-next]
 version = "7.0.0"
 default-features = false
-path = "../rust-ffmpeg-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ffmpeg-next"
-version = "6.1.1"
+version = "7.0.0"
 build   = "build.rs"
 
 authors = ["meh. <meh@schizofreni.co>", "Zhiming Wang <i@zhimingwang.org>"]
@@ -106,12 +106,13 @@ rpi = []
 
 [dependencies]
 libc     = "0.2"
-bitflags = "1.2"
+bitflags = "2.5"
 
 [dependencies.image]
-version  = "0.23"
+version  = "0.25"
 optional = true
 
 [dependencies.ffmpeg-sys-next]
-version = "6.1.0"
+version = "7.0.0"
 default-features = false
+path = "../rust-ffmpeg-sys"

--- a/examples/transcode-audio.rs
+++ b/examples/transcode-audio.rs
@@ -99,7 +99,10 @@ fn transcoder<P: AsRef<Path> + ?Sized>(
 
     encoder.set_rate(decoder.rate() as i32);
     encoder.set_channel_layout(channel_layout);
-    encoder.set_channels(channel_layout.channels());
+    #[cfg(not(feature = "ffmpeg_7_0"))]
+    {
+        encoder.set_channels(channel_layout.channels());
+    }
     encoder.set_format(
         codec
             .formats()

--- a/src/codec/capabilities.rs
+++ b/src/codec/capabilities.rs
@@ -2,6 +2,7 @@ use ffi::*;
 use libc::c_uint;
 
 bitflags! {
+    #[derive(Copy, Clone, PartialEq, Eq)]
     pub struct Capabilities: c_uint {
         const DRAW_HORIZ_BAND     = AV_CODEC_CAP_DRAW_HORIZ_BAND;
         const DR1                 = AV_CODEC_CAP_DR1;

--- a/src/codec/capabilities.rs
+++ b/src/codec/capabilities.rs
@@ -2,7 +2,7 @@ use ffi::*;
 use libc::c_uint;
 
 bitflags! {
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct Capabilities: c_uint {
         const DRAW_HORIZ_BAND     = AV_CODEC_CAP_DRAW_HORIZ_BAND;
         const DR1                 = AV_CODEC_CAP_DR1;

--- a/src/codec/debug.rs
+++ b/src/codec/debug.rs
@@ -2,6 +2,7 @@ use ffi::*;
 use libc::c_int;
 
 bitflags! {
+    #[derive(Copy, Clone, PartialEq, Eq)]
     pub struct Debug: c_int {
         const PICT_INFO   = FF_DEBUG_PICT_INFO;
         const RC          = FF_DEBUG_RC;

--- a/src/codec/debug.rs
+++ b/src/codec/debug.rs
@@ -2,7 +2,7 @@ use ffi::*;
 use libc::c_int;
 
 bitflags! {
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct Debug: c_int {
         const PICT_INFO   = FF_DEBUG_PICT_INFO;
         const RC          = FF_DEBUG_RC;

--- a/src/codec/decoder/audio.rs
+++ b/src/codec/decoder/audio.rs
@@ -48,7 +48,15 @@ impl Audio {
     }
 
     pub fn channels(&self) -> u16 {
-        unsafe { (*self.as_ptr()).channels as u16 }
+        #[cfg(not(feature = "ffmpeg_7_0"))]
+        unsafe {
+            (*self.as_ptr()).channels as u16
+        }
+
+        #[cfg(feature = "ffmpeg_7_0")]
+        {
+            self.channel_layout().channels() as u16
+        }
     }
 
     pub fn format(&self) -> format::Sample {
@@ -61,13 +69,16 @@ impl Audio {
         }
     }
 
-    #[cfg(not(feature = "ffmpeg_7_0"))]
     pub fn frames(&self) -> usize {
-        unsafe { (*self.as_ptr()).frame_number as usize }
-    }
-    #[cfg(feature = "ffmpeg_7_0")]
-    pub fn frames(&self) -> usize {
-        unsafe { (*self.as_ptr()).frame_num as usize }
+        #[cfg(not(feature = "ffmpeg_7_0"))]
+        unsafe {
+            (*self.as_ptr()).frame_number as usize
+        }
+
+        #[cfg(feature = "ffmpeg_7_0")]
+        unsafe {
+            (*self.as_ptr()).frame_num as usize
+        }
     }
 
     pub fn align(&self) -> usize {
@@ -75,15 +86,32 @@ impl Audio {
     }
 
     pub fn channel_layout(&self) -> ChannelLayout {
-        unsafe { ChannelLayout::from_bits_truncate((*self.as_ptr()).channel_layout) }
+        #[cfg(not(feature = "ffmpeg_7_0"))]
+        unsafe {
+            ChannelLayout::from_bits_truncate((*self.as_ptr()).channel_layout)
+        }
+
+        #[cfg(feature = "ffmpeg_7_0")]
+        unsafe {
+            ChannelLayout::from((*self.as_ptr()).ch_layout)
+        }
     }
 
     pub fn set_channel_layout(&mut self, value: ChannelLayout) {
         unsafe {
-            (*self.as_mut_ptr()).channel_layout = value.bits();
+            #[cfg(not(feature = "ffmpeg_7_0"))]
+            {
+                (*self.as_mut_ptr()).channel_layout = value.bits();
+            }
+
+            #[cfg(feature = "ffmpeg_7_0")]
+            {
+                (*self.as_mut_ptr()).ch_layout = value.into();
+            }
         }
     }
 
+    #[cfg(not(feature = "ffmpeg_7_0"))]
     pub fn request_channel_layout(&mut self, value: ChannelLayout) {
         unsafe {
             (*self.as_mut_ptr()).request_channel_layout = value.bits();

--- a/src/codec/decoder/audio.rs
+++ b/src/codec/decoder/audio.rs
@@ -61,8 +61,13 @@ impl Audio {
         }
     }
 
+    #[cfg(not(feature = "ffmpeg_7_0"))]
     pub fn frames(&self) -> usize {
         unsafe { (*self.as_ptr()).frame_number as usize }
+    }
+    #[cfg(feature = "ffmpeg_7_0")]
+    pub fn frames(&self) -> usize {
+        unsafe { (*self.as_ptr()).frame_num as usize }
     }
 
     pub fn align(&self) -> usize {

--- a/src/codec/decoder/check.rs
+++ b/src/codec/decoder/check.rs
@@ -2,6 +2,7 @@ use ffi::*;
 use libc::c_int;
 
 bitflags! {
+    #[derive(Copy, Clone, PartialEq, Eq)]
     pub struct Check: c_int {
         const CRC      = AV_EF_CRCCHECK;
         const BISTREAM = AV_EF_BITSTREAM;

--- a/src/codec/decoder/check.rs
+++ b/src/codec/decoder/check.rs
@@ -2,7 +2,7 @@ use ffi::*;
 use libc::c_int;
 
 bitflags! {
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct Check: c_int {
         const CRC      = AV_EF_CRCCHECK;
         const BISTREAM = AV_EF_BITSTREAM;

--- a/src/codec/decoder/conceal.rs
+++ b/src/codec/decoder/conceal.rs
@@ -2,7 +2,7 @@ use ffi::*;
 use libc::c_int;
 
 bitflags! {
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct Conceal: c_int {
         const GUESS_MVS   = FF_EC_GUESS_MVS;
         const DEBLOCK     = FF_EC_DEBLOCK;

--- a/src/codec/decoder/conceal.rs
+++ b/src/codec/decoder/conceal.rs
@@ -2,6 +2,7 @@ use ffi::*;
 use libc::c_int;
 
 bitflags! {
+    #[derive(Copy, Clone, PartialEq, Eq)]
     pub struct Conceal: c_int {
         const GUESS_MVS   = FF_EC_GUESS_MVS;
         const DEBLOCK     = FF_EC_DEBLOCK;

--- a/src/codec/decoder/decoder.rs
+++ b/src/codec/decoder/decoder.rs
@@ -54,7 +54,9 @@ impl Decoder {
     }
 
     pub fn video(self) -> Result<Video, Error> {
-        if let Some(codec) = super::find(self.id()) {
+        if let Some(codec) = self.codec() {
+            self.open_as(codec).and_then(|o| o.video())
+        } else if let Some(codec) = super::find(self.id()) {
             self.open_as(codec).and_then(|o| o.video())
         } else {
             Err(Error::DecoderNotFound)

--- a/src/codec/decoder/decoder.rs
+++ b/src/codec/decoder/decoder.rs
@@ -64,7 +64,9 @@ impl Decoder {
     }
 
     pub fn audio(self) -> Result<Audio, Error> {
-        if let Some(codec) = super::find(self.id()) {
+        if let Some(codec) = self.codec() {
+            self.open_as(codec).and_then(|o| o.audio())
+        } else if let Some(codec) = super::find(self.id()) {
             self.open_as(codec).and_then(|o| o.audio())
         } else {
             Err(Error::DecoderNotFound)

--- a/src/codec/decoder/slice.rs
+++ b/src/codec/decoder/slice.rs
@@ -2,7 +2,7 @@ use ffi::*;
 use libc::c_int;
 
 bitflags! {
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct Flags: c_int {
         const CODED_ORDER = SLICE_FLAG_CODED_ORDER;
         const ALLOW_FIELD = SLICE_FLAG_ALLOW_FIELD;

--- a/src/codec/decoder/slice.rs
+++ b/src/codec/decoder/slice.rs
@@ -2,6 +2,7 @@ use ffi::*;
 use libc::c_int;
 
 bitflags! {
+    #[derive(Copy, Clone, PartialEq, Eq)]
     pub struct Flags: c_int {
         const CODED_ORDER = SLICE_FLAG_CODED_ORDER;
         const ALLOW_FIELD = SLICE_FLAG_ALLOW_FIELD;

--- a/src/codec/decoder/video.rs
+++ b/src/codec/decoder/video.rs
@@ -84,6 +84,7 @@ impl Video {
         unsafe { chroma::Location::from((*self.as_ptr()).chroma_sample_location) }
     }
 
+    #[cfg(not(feature = "ffmpeg_7_0"))]
     pub fn set_slice_count(&mut self, value: usize) {
         unsafe {
             (*self.as_mut_ptr()).slice_count = value as c_int;

--- a/src/codec/encoder/audio.rs
+++ b/src/codec/encoder/audio.rs
@@ -95,14 +95,33 @@ impl Audio {
 
     pub fn set_channel_layout(&mut self, value: ChannelLayout) {
         unsafe {
-            (*self.as_mut_ptr()).channel_layout = value.bits();
+            #[cfg(not(feature = "ffmpeg_7_0"))]
+            {
+                (*self.as_mut_ptr()).channel_layout = value.bits();
+            }
+
+            #[cfg(feature = "ffmpeg_7_0")]
+            {
+                (*self.as_mut_ptr()).ch_layout = value.into();
+            }
         }
     }
 
     pub fn channel_layout(&self) -> ChannelLayout {
-        unsafe { ChannelLayout::from_bits_truncate((*self.as_ptr()).channel_layout) }
+        unsafe {
+            #[cfg(not(feature = "ffmpeg_7_0"))]
+            {
+                ChannelLayout::from_bits_truncate((*self.as_ptr()).channel_layout)
+            }
+
+            #[cfg(feature = "ffmpeg_7_0")]
+            {
+                ChannelLayout::from((*self.as_ptr()).ch_layout)
+            }
+        }
     }
 
+    #[cfg(not(feature = "ffmpeg_7_0"))]
     pub fn set_channels(&mut self, value: i32) {
         unsafe {
             (*self.as_mut_ptr()).channels = value;
@@ -110,7 +129,15 @@ impl Audio {
     }
 
     pub fn channels(&self) -> u16 {
-        unsafe { (*self.as_ptr()).channels as u16 }
+        #[cfg(not(feature = "ffmpeg_7_0"))]
+        unsafe {
+            (*self.as_ptr()).channels as u16
+        }
+
+        #[cfg(feature = "ffmpeg_7_0")]
+        {
+            self.channel_layout().channels() as u16
+        }
     }
 }
 

--- a/src/codec/flag.rs
+++ b/src/codec/flag.rs
@@ -2,7 +2,7 @@ use ffi::*;
 use libc::c_uint;
 
 bitflags! {
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct Flags: c_uint {
         const UNALIGNED       = AV_CODEC_FLAG_UNALIGNED;
         const QSCALE          = AV_CODEC_FLAG_QSCALE;

--- a/src/codec/flag.rs
+++ b/src/codec/flag.rs
@@ -2,6 +2,7 @@ use ffi::*;
 use libc::c_uint;
 
 bitflags! {
+    #[derive(Copy, Clone, PartialEq, Eq)]
     pub struct Flags: c_uint {
         const UNALIGNED       = AV_CODEC_FLAG_UNALIGNED;
         const QSCALE          = AV_CODEC_FLAG_QSCALE;

--- a/src/codec/id.rs
+++ b/src/codec/id.rs
@@ -211,6 +211,7 @@ pub enum Id {
     AVRP,
     V012,
     AVUI,
+    #[cfg(not(feature = "ffmpeg_7_0"))]
     AYUV,
     TARGA_Y216,
     V308,
@@ -659,6 +660,11 @@ pub enum Id {
     SMPTE_2038,
     #[cfg(feature = "ffmpeg_6_1")]
     OSQ,
+
+    #[cfg(feature = "ffmpeg_7_0")]
+    QOA,
+    #[cfg(feature = "ffmpeg_7_0")]
+    LEAD,
 }
 
 impl Id {
@@ -878,6 +884,7 @@ impl From<AVCodecID> for Id {
             AV_CODEC_ID_AVRP => Id::AVRP,
             AV_CODEC_ID_012V => Id::V012,
             AV_CODEC_ID_AVUI => Id::AVUI,
+            #[cfg(not(feature = "ffmpeg_7_0"))]
             AV_CODEC_ID_AYUV => Id::AYUV,
             AV_CODEC_ID_TARGA_Y216 => Id::TARGA_Y216,
             AV_CODEC_ID_V308 => Id::V308,
@@ -1325,6 +1332,11 @@ impl From<AVCodecID> for Id {
             AV_CODEC_ID_SMPTE_2038 => Id::SMPTE_2038,
             #[cfg(feature = "ffmpeg_6_1")]
             AV_CODEC_ID_OSQ => Id::OSQ,
+
+            #[cfg(feature = "ffmpeg_7_0")]
+            AV_CODEC_ID_QOA => Id::QOA,
+            #[cfg(feature = "ffmpeg_7_0")]
+            AV_CODEC_ID_LEAD => Id::LEAD,
         }
     }
 }
@@ -1535,6 +1547,7 @@ impl From<Id> for AVCodecID {
             Id::AVRP => AV_CODEC_ID_AVRP,
             Id::V012 => AV_CODEC_ID_012V,
             Id::AVUI => AV_CODEC_ID_AVUI,
+            #[cfg(not(feature = "ffmpeg_7_0"))]
             Id::AYUV => AV_CODEC_ID_AYUV,
             Id::TARGA_Y216 => AV_CODEC_ID_TARGA_Y216,
             Id::V308 => AV_CODEC_ID_V308,
@@ -1983,6 +1996,11 @@ impl From<Id> for AVCodecID {
             Id::SMPTE_2038 => AV_CODEC_ID_SMPTE_2038,
             #[cfg(feature = "ffmpeg_6_1")]
             Id::OSQ => AV_CODEC_ID_OSQ,
+
+            #[cfg(feature = "ffmpeg_7_0")]
+            Id::QOA => AV_CODEC_ID_QOA,
+            #[cfg(feature = "ffmpeg_7_0")]
+            Id::LEAD => AV_CODEC_ID_LEAD,
         }
     }
 }

--- a/src/codec/packet/flag.rs
+++ b/src/codec/packet/flag.rs
@@ -2,7 +2,7 @@ use ffi::*;
 use libc::c_int;
 
 bitflags! {
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct Flags: c_int {
         const KEY     = AV_PKT_FLAG_KEY;
         const CORRUPT = AV_PKT_FLAG_CORRUPT;

--- a/src/codec/packet/flag.rs
+++ b/src/codec/packet/flag.rs
@@ -2,6 +2,7 @@ use ffi::*;
 use libc::c_int;
 
 bitflags! {
+    #[derive(Copy, Clone, PartialEq, Eq)]
     pub struct Flags: c_int {
         const KEY     = AV_PKT_FLAG_KEY;
         const CORRUPT = AV_PKT_FLAG_CORRUPT;

--- a/src/codec/packet/side_data.rs
+++ b/src/codec/packet/side_data.rs
@@ -54,6 +54,15 @@ pub enum Type {
 
     #[cfg(feature = "ffmpeg_5_0")]
     DYNAMIC_HDR10_PLUS,
+
+    #[cfg(feature = "ffmpeg_7_0")]
+    IAMF_MIX_GAIN_PARAM,
+    #[cfg(feature = "ffmpeg_7_0")]
+    IAMF_DEMIXING_INFO_PARAM,
+    #[cfg(feature = "ffmpeg_7_0")]
+    IAMF_RECON_GAIN_INFO_PARAM,
+    #[cfg(feature = "ffmpeg_7_0")]
+    AMBIENT_VIEWING_ENVIRONMENT,
 }
 
 impl From<AVPacketSideDataType> for Type {
@@ -106,6 +115,15 @@ impl From<AVPacketSideDataType> for Type {
 
             #[cfg(feature = "ffmpeg_5_0")]
             AV_PKT_DATA_DYNAMIC_HDR10_PLUS => Type::DYNAMIC_HDR10_PLUS,
+
+            #[cfg(feature = "ffmpeg_7_0")]
+            AV_PKT_DATA_IAMF_MIX_GAIN_PARAM => Type::IAMF_MIX_GAIN_PARAM,
+            #[cfg(feature = "ffmpeg_7_0")]
+            AV_PKT_DATA_IAMF_DEMIXING_INFO_PARAM => Type::IAMF_DEMIXING_INFO_PARAM,
+            #[cfg(feature = "ffmpeg_7_0")]
+            AV_PKT_DATA_IAMF_RECON_GAIN_INFO_PARAM => Type::IAMF_RECON_GAIN_INFO_PARAM,
+            #[cfg(feature = "ffmpeg_7_0")]
+            AV_PKT_DATA_AMBIENT_VIEWING_ENVIRONMENT => Type::AMBIENT_VIEWING_ENVIRONMENT,
         }
     }
 }
@@ -160,6 +178,15 @@ impl From<Type> for AVPacketSideDataType {
 
             #[cfg(feature = "ffmpeg_5_0")]
             Type::DYNAMIC_HDR10_PLUS => AV_PKT_DATA_DYNAMIC_HDR10_PLUS,
+
+            #[cfg(feature = "ffmpeg_7_0")]
+            Type::IAMF_MIX_GAIN_PARAM => AV_PKT_DATA_IAMF_MIX_GAIN_PARAM,
+            #[cfg(feature = "ffmpeg_7_0")]
+            Type::IAMF_DEMIXING_INFO_PARAM => AV_PKT_DATA_IAMF_DEMIXING_INFO_PARAM,
+            #[cfg(feature = "ffmpeg_7_0")]
+            Type::IAMF_RECON_GAIN_INFO_PARAM => AV_PKT_DATA_IAMF_RECON_GAIN_INFO_PARAM,
+            #[cfg(feature = "ffmpeg_7_0")]
+            Type::AMBIENT_VIEWING_ENVIRONMENT => AV_PKT_DATA_AMBIENT_VIEWING_ENVIRONMENT,
         }
     }
 }

--- a/src/codec/subtitle/flag.rs
+++ b/src/codec/subtitle/flag.rs
@@ -2,6 +2,7 @@ use ffi::*;
 use libc::c_int;
 
 bitflags! {
+    #[derive(Copy, Clone, PartialEq, Eq)]
     pub struct Flags: c_int {
         const FORCED = AV_SUBTITLE_FLAG_FORCED;
     }

--- a/src/codec/subtitle/flag.rs
+++ b/src/codec/subtitle/flag.rs
@@ -2,7 +2,7 @@ use ffi::*;
 use libc::c_int;
 
 bitflags! {
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct Flags: c_int {
         const FORCED = AV_SUBTITLE_FLAG_FORCED;
     }

--- a/src/filter/context/context.rs
+++ b/src/filter/context/context.rs
@@ -50,7 +50,14 @@ impl<'a> Context<'a> {
     }
 
     pub fn set_channel_layout(&mut self, value: ChannelLayout) {
-        let _ = option::Settable::set(self, "channel_layouts", &value.bits());
+        #[cfg(not(feature = "ffmpeg_7_0"))]
+        {
+            let _ = option::Settable::set(self, "channel_layouts", &value.bits());
+        }
+        #[cfg(feature = "ffmpeg_7_0")]
+        {
+            let _ = option::Settable::set_channel_layout(self, "channel_layouts", value);
+        }
     }
 }
 

--- a/src/filter/flag.rs
+++ b/src/filter/flag.rs
@@ -2,7 +2,7 @@ use ffi::*;
 use libc::c_int;
 
 bitflags! {
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct Flags: c_int {
         const DYNAMIC_INPUTS            = AVFILTER_FLAG_DYNAMIC_INPUTS;
         const DYNAMIC_OUTPUTS           = AVFILTER_FLAG_DYNAMIC_OUTPUTS;

--- a/src/filter/flag.rs
+++ b/src/filter/flag.rs
@@ -2,6 +2,7 @@ use ffi::*;
 use libc::c_int;
 
 bitflags! {
+    #[derive(Copy, Clone, PartialEq, Eq)]
     pub struct Flags: c_int {
         const DYNAMIC_INPUTS            = AVFILTER_FLAG_DYNAMIC_INPUTS;
         const DYNAMIC_OUTPUTS           = AVFILTER_FLAG_DYNAMIC_OUTPUTS;

--- a/src/format/format/flag.rs
+++ b/src/format/format/flag.rs
@@ -2,6 +2,7 @@ use ffi::*;
 use libc::c_int;
 
 bitflags! {
+    #[derive(Copy, Clone, PartialEq, Eq)]
     pub struct Flags: c_int {
         const NO_FILE       = AVFMT_NOFILE;
         const NEED_NUMBER   = AVFMT_NEEDNUMBER;

--- a/src/format/format/flag.rs
+++ b/src/format/format/flag.rs
@@ -2,7 +2,7 @@ use ffi::*;
 use libc::c_int;
 
 bitflags! {
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct Flags: c_int {
         const NO_FILE       = AVFMT_NOFILE;
         const NEED_NUMBER   = AVFMT_NEEDNUMBER;

--- a/src/format/stream/disposition.rs
+++ b/src/format/stream/disposition.rs
@@ -2,6 +2,7 @@ use ffi::*;
 use libc::c_int;
 
 bitflags! {
+    #[derive(Copy, Clone, PartialEq, Eq)]
     pub struct Disposition: c_int {
         const DEFAULT          = AV_DISPOSITION_DEFAULT;
         const DUB              = AV_DISPOSITION_DUB;

--- a/src/format/stream/disposition.rs
+++ b/src/format/stream/disposition.rs
@@ -2,7 +2,7 @@ use ffi::*;
 use libc::c_int;
 
 bitflags! {
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct Disposition: c_int {
         const DEFAULT          = AV_DISPOSITION_DEFAULT;
         const DUB              = AV_DISPOSITION_DUB;

--- a/src/software/resampling/flag.rs
+++ b/src/software/resampling/flag.rs
@@ -2,6 +2,7 @@ use ffi::*;
 use libc::c_int;
 
 bitflags! {
+    #[derive(Copy, Clone, PartialEq, Eq)]
     pub struct Flags: c_int {
         const FORCE = SWR_FLAG_RESAMPLE;
     }

--- a/src/software/resampling/flag.rs
+++ b/src/software/resampling/flag.rs
@@ -2,7 +2,7 @@ use ffi::*;
 use libc::c_int;
 
 bitflags! {
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct Flags: c_int {
         const FORCE = SWR_FLAG_RESAMPLE;
     }

--- a/src/software/scaling/flag.rs
+++ b/src/software/scaling/flag.rs
@@ -2,6 +2,7 @@ use ffi::*;
 use libc::c_int;
 
 bitflags! {
+    #[derive(Copy, Clone, PartialEq, Eq)]
     pub struct Flags: c_int {
         const FAST_BILINEAR        = SWS_FAST_BILINEAR;
         const BILINEAR             = SWS_BILINEAR;

--- a/src/software/scaling/flag.rs
+++ b/src/software/scaling/flag.rs
@@ -2,7 +2,7 @@ use ffi::*;
 use libc::c_int;
 
 bitflags! {
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct Flags: c_int {
         const FAST_BILINEAR        = SWS_FAST_BILINEAR;
         const BILINEAR             = SWS_BILINEAR;

--- a/src/util/channel_layout.rs
+++ b/src/util/channel_layout.rs
@@ -16,6 +16,16 @@ impl PartialEq for ChannelLayout {
 }
 impl Eq for ChannelLayout {}
 
+impl std::fmt::Debug for ChannelLayout {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let mut s = fmt.debug_struct("ChannelLayout");
+        s.field("is_empty", &self.is_empty());
+        s.field("channels", &self.channels());
+        s.field("u.mask", &unsafe { self.0.u.mask });
+        s.finish()
+    }
+}
+
 macro_rules! define_layout {
     ($name:ident, $nb:expr, $mask:expr) => {
         pub const $name: ChannelLayout = ChannelLayout(AVChannelLayout {
@@ -70,6 +80,11 @@ impl ChannelLayout {
     #[inline]
     pub fn channels(&self) -> i32 {
         self.0.nb_channels
+    }
+
+    #[inline]
+    pub fn bits(&self) -> u64 {
+        unsafe { self.0.u.mask }
     }
 
     pub fn default(number: i32) -> ChannelLayout {

--- a/src/util/channel_layout.rs
+++ b/src/util/channel_layout.rs
@@ -1,86 +1,102 @@
 use ffi::*;
-use libc::c_ulonglong;
 
-bitflags! {
-    pub struct ChannelLayout: c_ulonglong {
-        const FRONT_LEFT            = AV_CH_FRONT_LEFT;
-        const FRONT_RIGHT           = AV_CH_FRONT_RIGHT;
-        const FRONT_CENTER          = AV_CH_FRONT_CENTER;
-        const LOW_FREQUENCY         = AV_CH_LOW_FREQUENCY;
-        const BACK_LEFT             = AV_CH_BACK_LEFT;
-        const BACK_RIGHT            = AV_CH_BACK_RIGHT;
-        const FRONT_LEFT_OF_CENTER  = AV_CH_FRONT_LEFT_OF_CENTER;
-        const FRONT_RIGHT_OF_CENTER = AV_CH_FRONT_RIGHT_OF_CENTER;
-        const BACK_CENTER           = AV_CH_BACK_CENTER;
-        const SIDE_LEFT             = AV_CH_SIDE_LEFT;
-        const SIDE_RIGHT            = AV_CH_SIDE_RIGHT;
-        const TOP_CENTER            = AV_CH_TOP_CENTER;
-        const TOP_FRONT_LEFT        = AV_CH_TOP_FRONT_LEFT;
-        const TOP_FRONT_CENTER      = AV_CH_TOP_FRONT_CENTER;
-        const TOP_FRONT_RIGHT       = AV_CH_TOP_FRONT_RIGHT;
-        const TOP_BACK_LEFT         = AV_CH_TOP_BACK_LEFT;
-        const TOP_BACK_CENTER       = AV_CH_TOP_BACK_CENTER;
-        const TOP_BACK_RIGHT        = AV_CH_TOP_BACK_RIGHT;
-        const STEREO_LEFT           = AV_CH_STEREO_LEFT;
-        const STEREO_RIGHT          = AV_CH_STEREO_RIGHT;
-        const WIDE_LEFT             = AV_CH_WIDE_LEFT;
-        const WIDE_RIGHT            = AV_CH_WIDE_RIGHT;
-        const SURROUND_DIRECT_LEFT  = AV_CH_SURROUND_DIRECT_LEFT;
-        const SURROUND_DIRECT_RIGHT = AV_CH_SURROUND_DIRECT_RIGHT;
-        const LOW_FREQUENCY_2       = AV_CH_LOW_FREQUENCY_2;
-        const NATIVE                = AV_CH_LAYOUT_NATIVE;
+#[repr(transparent)]
+#[derive(Copy, Clone)]
+pub struct ChannelLayout(pub AVChannelLayout);
 
-        const MONO               = AV_CH_LAYOUT_MONO;
-        const STEREO             = AV_CH_LAYOUT_STEREO;
-        const _2POINT1           = AV_CH_LAYOUT_2POINT1;
-        const _2_1               = AV_CH_LAYOUT_2_1;
-        const SURROUND           = AV_CH_LAYOUT_SURROUND;
-        const _3POINT1           = AV_CH_LAYOUT_3POINT1;
-        const _4POINT0           = AV_CH_LAYOUT_4POINT0;
-        const _4POINT1           = AV_CH_LAYOUT_4POINT1;
-        const _2_2               = AV_CH_LAYOUT_2_2;
-        const QUAD               = AV_CH_LAYOUT_QUAD;
-        const _5POINT0           = AV_CH_LAYOUT_5POINT0;
-        const _5POINT1           = AV_CH_LAYOUT_5POINT1;
-        const _5POINT0_BACK      = AV_CH_LAYOUT_5POINT0_BACK;
-        const _5POINT1_BACK      = AV_CH_LAYOUT_5POINT1_BACK;
-        const _6POINT0           = AV_CH_LAYOUT_6POINT0;
-        const _6POINT0_FRONT     = AV_CH_LAYOUT_6POINT0_FRONT;
-        const HEXAGONAL          = AV_CH_LAYOUT_HEXAGONAL;
-        const _6POINT1           = AV_CH_LAYOUT_6POINT1;
-        const _6POINT1_BACK      = AV_CH_LAYOUT_6POINT1_BACK;
-        const _6POINT1_FRONT     = AV_CH_LAYOUT_6POINT1_FRONT;
-        const _7POINT0           = AV_CH_LAYOUT_7POINT0;
-        const _7POINT0_FRONT     = AV_CH_LAYOUT_7POINT0_FRONT;
-        const _7POINT1           = AV_CH_LAYOUT_7POINT1;
-        const _7POINT1_WIDE      = AV_CH_LAYOUT_7POINT1_WIDE;
-        const _7POINT1_WIDE_BACK = AV_CH_LAYOUT_7POINT1_WIDE_BACK;
-        const OCTAGONAL          = AV_CH_LAYOUT_OCTAGONAL;
-        const HEXADECAGONAL      = AV_CH_LAYOUT_HEXADECAGONAL;
-        const STEREO_DOWNMIX     = AV_CH_LAYOUT_STEREO_DOWNMIX;
-
-        #[cfg(feature = "ffmpeg_6_1")]
-        const _3POINT1POINT2      = AV_CH_LAYOUT_3POINT1POINT2;
-        #[cfg(feature = "ffmpeg_6_1")]
-        const _5POINT1POINT2_BACK = AV_CH_LAYOUT_5POINT1POINT2_BACK;
-        #[cfg(feature = "ffmpeg_6_1")]
-        const _5POINT1POINT4_BACK = AV_CH_LAYOUT_5POINT1POINT4_BACK;
-        #[cfg(feature = "ffmpeg_6_1")]
-        const _7POINT1POINT2      = AV_CH_LAYOUT_7POINT1POINT2;
-        #[cfg(feature = "ffmpeg_6_1")]
-        const _7POINT1POINT4_BACK = AV_CH_LAYOUT_7POINT1POINT4_BACK;
+impl PartialEq for ChannelLayout {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe {
+            self.0.order == other.0.order
+                && self.0.nb_channels == other.0.nb_channels
+                && self.0.u.mask == other.0.u.mask
+                && self.0.opaque == other.0.opaque
+        }
     }
+}
+impl Eq for ChannelLayout {}
+
+macro_rules! define_layout {
+    ($name:ident, $nb:expr, $mask:expr) => {
+        pub const $name: ChannelLayout = ChannelLayout(AVChannelLayout {
+            order: AVChannelOrder::AV_CHANNEL_ORDER_NATIVE,
+            nb_channels: $nb,
+            u: AVChannelLayout__bindgen_ty_1 { mask: $mask },
+            opaque: std::ptr::null_mut(),
+        });
+    };
 }
 
 impl ChannelLayout {
+    define_layout!(MONO, 1, AV_CH_LAYOUT_MONO);
+    define_layout!(STEREO, 2, AV_CH_LAYOUT_STEREO);
+    define_layout!(_2POINT1, 3, AV_CH_LAYOUT_2POINT1);
+    define_layout!(_2_1, 3, AV_CH_LAYOUT_2_1);
+    define_layout!(SURROUND, 3, AV_CH_LAYOUT_SURROUND);
+    define_layout!(_3POINT1, 4, AV_CH_LAYOUT_3POINT1);
+    define_layout!(_4POINT0, 4, AV_CH_LAYOUT_4POINT0);
+    define_layout!(_4POINT1, 5, AV_CH_LAYOUT_4POINT1);
+    define_layout!(_2_2, 4, AV_CH_LAYOUT_2_2);
+    define_layout!(QUAD, 4, AV_CH_LAYOUT_QUAD);
+    define_layout!(_5POINT0, 5, AV_CH_LAYOUT_5POINT0);
+    define_layout!(_5POINT1, 6, AV_CH_LAYOUT_5POINT1);
+    define_layout!(_5POINT0_BACK, 5, AV_CH_LAYOUT_5POINT0_BACK);
+    define_layout!(_5POINT1_BACK, 6, AV_CH_LAYOUT_5POINT1_BACK);
+    define_layout!(_6POINT0, 6, AV_CH_LAYOUT_6POINT0);
+    define_layout!(_6POINT0_FRONT, 6, AV_CH_LAYOUT_6POINT0_FRONT);
+    define_layout!(_3POINT1POINT2, 6, AV_CH_LAYOUT_3POINT1POINT2);
+    define_layout!(HEXAGONAL, 6, AV_CH_LAYOUT_HEXAGONAL);
+    define_layout!(_6POINT1, 7, AV_CH_LAYOUT_6POINT1);
+    define_layout!(_6POINT1_BACK, 7, AV_CH_LAYOUT_6POINT1_BACK);
+    define_layout!(_6POINT1_FRONT, 7, AV_CH_LAYOUT_6POINT1_FRONT);
+    define_layout!(_7POINT0, 7, AV_CH_LAYOUT_7POINT0);
+    define_layout!(_7POINT0_FRONT, 7, AV_CH_LAYOUT_7POINT0_FRONT);
+    define_layout!(_7POINT1, 8, AV_CH_LAYOUT_7POINT1);
+    define_layout!(_7POINT1_WIDE, 8, AV_CH_LAYOUT_7POINT1_WIDE);
+    define_layout!(_7POINT1_WIDE_BACK, 8, AV_CH_LAYOUT_7POINT1_WIDE_BACK);
+    define_layout!(_5POINT1POINT2_BACK, 8, AV_CH_LAYOUT_5POINT1POINT2_BACK);
+    define_layout!(OCTAGONAL, 8, AV_CH_LAYOUT_OCTAGONAL);
+    define_layout!(CUBE, 8, AV_CH_LAYOUT_CUBE);
+    define_layout!(_5POINT1POINT4_BACK, 10, AV_CH_LAYOUT_5POINT1POINT4_BACK);
+    define_layout!(_7POINT1POINT2, 10, AV_CH_LAYOUT_7POINT1POINT2);
+    define_layout!(_7POINT1POINT4_BACK, 12, AV_CH_LAYOUT_7POINT1POINT4_BACK);
+    define_layout!(_7POINT2POINT3, 12, AV_CH_LAYOUT_7POINT2POINT3);
+    define_layout!(_9POINT1POINT4_BACK, 14, AV_CH_LAYOUT_9POINT1POINT4_BACK);
+    define_layout!(HEXADECAGONAL, 16, AV_CH_LAYOUT_HEXADECAGONAL);
+    define_layout!(STEREO_DOWNMIX, 2, AV_CH_LAYOUT_STEREO_DOWNMIX);
+    define_layout!(_22POINT2, 24, AV_CH_LAYOUT_22POINT2);
+    define_layout!(_7POINT1_TOP_BACK, 8, AV_CH_LAYOUT_5POINT1POINT2_BACK);
+
     #[inline]
     pub fn channels(&self) -> i32 {
-        unsafe { av_get_channel_layout_nb_channels(self.bits()) }
+        self.0.nb_channels
     }
 
     pub fn default(number: i32) -> ChannelLayout {
         unsafe {
-            ChannelLayout::from_bits_truncate(av_get_default_channel_layout(number) as c_ulonglong)
+            let mut channel_layout = std::mem::zeroed();
+            av_channel_layout_default(&mut channel_layout, number);
+            ChannelLayout(channel_layout)
         }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        unsafe {
+            self.0.order == AVChannelOrder::AV_CHANNEL_ORDER_UNSPEC
+                && self.0.nb_channels == 0
+                && self.0.u.mask == 0
+        }
+    }
+}
+
+impl From<AVChannelLayout> for ChannelLayout {
+    fn from(value: AVChannelLayout) -> Self {
+        Self(value)
+    }
+}
+
+impl From<ChannelLayout> for AVChannelLayout {
+    fn from(value: ChannelLayout) -> Self {
+        value.0
     }
 }

--- a/src/util/format/pixel.rs
+++ b/src/util/format/pixel.rs
@@ -222,7 +222,7 @@ pub enum Pixel {
     VIDEOTOOLBOX,
 
     // --- defaults
-    #[cfg(feature = "ffmpeg_4_0")]
+    #[cfg(all(feature = "ffmpeg_4_0", not(feature = "ffmpeg_7_0")))]
     XVMC,
 
     RGB32,
@@ -414,6 +414,9 @@ pub enum Pixel {
     #[cfg(feature = "ffmpeg_6_1")]
     GBRAP14LE,
 
+    #[cfg(feature = "ffmpeg_7_0")]
+    D3D12,
+
     #[cfg(feature = "rpi")]
     SAND128,
     #[cfg(feature = "rpi")]
@@ -493,7 +496,7 @@ impl From<AVPixelFormat> for Pixel {
             AV_PIX_FMT_YUVJ420P => Pixel::YUVJ420P,
             AV_PIX_FMT_YUVJ422P => Pixel::YUVJ422P,
             AV_PIX_FMT_YUVJ444P => Pixel::YUVJ444P,
-            #[cfg(feature = "ffmpeg_4_0")]
+            #[cfg(all(feature = "ffmpeg_4_0", not(feature = "ffmpeg_7_0")))]
             AV_PIX_FMT_XVMC => Pixel::XVMC,
             #[cfg(all(feature = "ff_api_xvmc", not(feature = "ffmpeg_5_0")))]
             AV_PIX_FMT_XVMC_MPEG2_MC => Pixel::XVMC_MPEG2_MC,
@@ -820,6 +823,9 @@ impl From<AVPixelFormat> for Pixel {
             #[cfg(feature = "ffmpeg_6_1")]
             AV_PIX_FMT_GBRAP14LE => Pixel::GBRAP14LE,
 
+            #[cfg(feature = "ffmpeg_7_0")]
+            AV_PIX_FMT_D3D12 => Pixel::D3D12,
+
             #[cfg(feature = "rpi")]
             AV_PIX_FMT_SAND128 => Pixel::SAND128,
             #[cfg(feature = "rpi")]
@@ -1052,7 +1058,7 @@ impl From<Pixel> for AVPixelFormat {
             Pixel::VIDEOTOOLBOX => AV_PIX_FMT_VIDEOTOOLBOX,
 
             // --- defaults
-            #[cfg(feature = "ffmpeg_4_0")]
+            #[cfg(all(feature = "ffmpeg_4_0", not(feature = "ffmpeg_7_0")))]
             Pixel::XVMC => AV_PIX_FMT_XVMC,
 
             Pixel::RGB32 => AV_PIX_FMT_RGB32,
@@ -1243,6 +1249,9 @@ impl From<Pixel> for AVPixelFormat {
             Pixel::GBRAP14BE => AV_PIX_FMT_GBRAP14BE,
             #[cfg(feature = "ffmpeg_6_1")]
             Pixel::GBRAP14LE => AV_PIX_FMT_GBRAP14LE,
+
+            #[cfg(feature = "ffmpeg_7_0")]
+            Pixel::D3D12 => AV_PIX_FMT_D3D12,
 
             #[cfg(feature = "rpi")]
             Pixel::SAND128 => AV_PIX_FMT_SAND128,

--- a/src/util/frame/flag.rs
+++ b/src/util/frame/flag.rs
@@ -2,7 +2,7 @@ use ffi::*;
 use libc::c_int;
 
 bitflags! {
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct Flags: c_int {
         const CORRUPT = AV_FRAME_FLAG_CORRUPT;
     }

--- a/src/util/frame/flag.rs
+++ b/src/util/frame/flag.rs
@@ -2,6 +2,7 @@ use ffi::*;
 use libc::c_int;
 
 bitflags! {
+    #[derive(Copy, Clone, PartialEq, Eq)]
     pub struct Flags: c_int {
         const CORRUPT = AV_FRAME_FLAG_CORRUPT;
     }

--- a/src/util/frame/mod.rs
+++ b/src/util/frame/mod.rs
@@ -79,7 +79,11 @@ impl Frame {
     pub fn packet(&self) -> Packet {
         unsafe {
             Packet {
+                #[cfg(not(feature = "ffmpeg_7_0"))]
                 duration: (*self.as_ptr()).pkt_duration,
+                #[cfg(feature = "ffmpeg_7_0")]
+                duration: (*self.as_ptr()).duration,
+
                 position: (*self.as_ptr()).pkt_pos,
                 size: (*self.as_ptr()).pkt_size as usize,
 

--- a/src/util/frame/video.rs
+++ b/src/util/frame/video.rs
@@ -174,11 +174,13 @@ impl Video {
     }
 
     #[inline]
+    #[cfg(not(feature = "ffmpeg_7_0"))]
     pub fn coded_number(&self) -> usize {
         unsafe { (*self.as_ptr()).coded_picture_number as usize }
     }
 
     #[inline]
+    #[cfg(not(feature = "ffmpeg_7_0"))]
     pub fn display_number(&self) -> usize {
         unsafe { (*self.as_ptr()).display_picture_number as usize }
     }

--- a/src/util/legacy_channel_layout.rs
+++ b/src/util/legacy_channel_layout.rs
@@ -2,7 +2,7 @@ use ffi::*;
 use libc::c_ulonglong;
 
 bitflags! {
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct ChannelLayout: c_ulonglong {
         const FRONT_LEFT            = AV_CH_FRONT_LEFT;
         const FRONT_RIGHT           = AV_CH_FRONT_RIGHT;

--- a/src/util/legacy_channel_layout.rs
+++ b/src/util/legacy_channel_layout.rs
@@ -1,0 +1,88 @@
+use ffi::*;
+use libc::c_ulonglong;
+
+bitflags! {
+    #[derive(Copy, Clone, PartialEq, Eq)]
+    pub struct ChannelLayout: c_ulonglong {
+        const FRONT_LEFT            = AV_CH_FRONT_LEFT;
+        const FRONT_RIGHT           = AV_CH_FRONT_RIGHT;
+        const FRONT_CENTER          = AV_CH_FRONT_CENTER;
+        const LOW_FREQUENCY         = AV_CH_LOW_FREQUENCY;
+        const BACK_LEFT             = AV_CH_BACK_LEFT;
+        const BACK_RIGHT            = AV_CH_BACK_RIGHT;
+        const FRONT_LEFT_OF_CENTER  = AV_CH_FRONT_LEFT_OF_CENTER;
+        const FRONT_RIGHT_OF_CENTER = AV_CH_FRONT_RIGHT_OF_CENTER;
+        const BACK_CENTER           = AV_CH_BACK_CENTER;
+        const SIDE_LEFT             = AV_CH_SIDE_LEFT;
+        const SIDE_RIGHT            = AV_CH_SIDE_RIGHT;
+        const TOP_CENTER            = AV_CH_TOP_CENTER;
+        const TOP_FRONT_LEFT        = AV_CH_TOP_FRONT_LEFT;
+        const TOP_FRONT_CENTER      = AV_CH_TOP_FRONT_CENTER;
+        const TOP_FRONT_RIGHT       = AV_CH_TOP_FRONT_RIGHT;
+        const TOP_BACK_LEFT         = AV_CH_TOP_BACK_LEFT;
+        const TOP_BACK_CENTER       = AV_CH_TOP_BACK_CENTER;
+        const TOP_BACK_RIGHT        = AV_CH_TOP_BACK_RIGHT;
+        const STEREO_LEFT           = AV_CH_STEREO_LEFT;
+        const STEREO_RIGHT          = AV_CH_STEREO_RIGHT;
+        const WIDE_LEFT             = AV_CH_WIDE_LEFT;
+        const WIDE_RIGHT            = AV_CH_WIDE_RIGHT;
+        const SURROUND_DIRECT_LEFT  = AV_CH_SURROUND_DIRECT_LEFT;
+        const SURROUND_DIRECT_RIGHT = AV_CH_SURROUND_DIRECT_RIGHT;
+        const LOW_FREQUENCY_2       = AV_CH_LOW_FREQUENCY_2;
+
+        const MONO               = AV_CH_LAYOUT_MONO;
+        const STEREO             = AV_CH_LAYOUT_STEREO;
+        const _2POINT1           = AV_CH_LAYOUT_2POINT1;
+        const _2_1               = AV_CH_LAYOUT_2_1;
+        const SURROUND           = AV_CH_LAYOUT_SURROUND;
+        const _3POINT1           = AV_CH_LAYOUT_3POINT1;
+        const _4POINT0           = AV_CH_LAYOUT_4POINT0;
+        const _4POINT1           = AV_CH_LAYOUT_4POINT1;
+        const _2_2               = AV_CH_LAYOUT_2_2;
+        const QUAD               = AV_CH_LAYOUT_QUAD;
+        const _5POINT0           = AV_CH_LAYOUT_5POINT0;
+        const _5POINT1           = AV_CH_LAYOUT_5POINT1;
+        const _5POINT0_BACK      = AV_CH_LAYOUT_5POINT0_BACK;
+        const _5POINT1_BACK      = AV_CH_LAYOUT_5POINT1_BACK;
+        const _6POINT0           = AV_CH_LAYOUT_6POINT0;
+        const _6POINT0_FRONT     = AV_CH_LAYOUT_6POINT0_FRONT;
+        const HEXAGONAL          = AV_CH_LAYOUT_HEXAGONAL;
+        const _6POINT1           = AV_CH_LAYOUT_6POINT1;
+        const _6POINT1_BACK      = AV_CH_LAYOUT_6POINT1_BACK;
+        const _6POINT1_FRONT     = AV_CH_LAYOUT_6POINT1_FRONT;
+        const _7POINT0           = AV_CH_LAYOUT_7POINT0;
+        const _7POINT0_FRONT     = AV_CH_LAYOUT_7POINT0_FRONT;
+        const _7POINT1           = AV_CH_LAYOUT_7POINT1;
+        const _7POINT1_WIDE      = AV_CH_LAYOUT_7POINT1_WIDE;
+        const _7POINT1_WIDE_BACK = AV_CH_LAYOUT_7POINT1_WIDE_BACK;
+        const OCTAGONAL          = AV_CH_LAYOUT_OCTAGONAL;
+        const HEXADECAGONAL      = AV_CH_LAYOUT_HEXADECAGONAL;
+        const STEREO_DOWNMIX     = AV_CH_LAYOUT_STEREO_DOWNMIX;
+
+        #[cfg(feature = "ffmpeg_6_1")]
+        const _3POINT1POINT2      = AV_CH_LAYOUT_3POINT1POINT2;
+        #[cfg(feature = "ffmpeg_6_1")]
+        const _5POINT1POINT2_BACK = AV_CH_LAYOUT_5POINT1POINT2_BACK;
+        #[cfg(feature = "ffmpeg_6_1")]
+        const _5POINT1POINT4_BACK = AV_CH_LAYOUT_5POINT1POINT4_BACK;
+        #[cfg(feature = "ffmpeg_6_1")]
+        const _7POINT1POINT2      = AV_CH_LAYOUT_7POINT1POINT2;
+        #[cfg(feature = "ffmpeg_6_1")]
+        const _7POINT1POINT4_BACK = AV_CH_LAYOUT_7POINT1POINT4_BACK;
+        #[cfg(feature = "ffmpeg_6_1")]
+        const CUBE = AV_CH_LAYOUT_CUBE;
+    }
+}
+
+impl ChannelLayout {
+    #[inline]
+    pub fn channels(&self) -> i32 {
+        unsafe { av_get_channel_layout_nb_channels(self.bits()) }
+    }
+
+    pub fn default(number: i32) -> ChannelLayout {
+        unsafe {
+            ChannelLayout::from_bits_truncate(av_get_default_channel_layout(number) as c_ulonglong)
+        }
+    }
+}

--- a/src/util/log/flag.rs
+++ b/src/util/log/flag.rs
@@ -2,6 +2,7 @@ use ffi::*;
 use libc::c_int;
 
 bitflags! {
+    #[derive(Copy, Clone, PartialEq, Eq)]
     pub struct Flags: c_int {
         const SKIP_REPEATED = AV_LOG_SKIP_REPEATED;
         const PRINT_LEVEL = AV_LOG_PRINT_LEVEL;

--- a/src/util/log/flag.rs
+++ b/src/util/log/flag.rs
@@ -2,7 +2,7 @@ use ffi::*;
 use libc::c_int;
 
 bitflags! {
-    #[derive(Copy, Clone, PartialEq, Eq)]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct Flags: c_int {
         const SKIP_REPEATED = AV_LOG_SKIP_REPEATED;
         const PRINT_LEVEL = AV_LOG_PRINT_LEVEL;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,6 +1,5 @@
 #[macro_use]
 pub mod dictionary;
-pub mod channel_layout;
 pub mod chroma;
 pub mod color;
 pub mod error;
@@ -15,6 +14,10 @@ pub mod picture;
 pub mod range;
 pub mod rational;
 pub mod time;
+
+#[cfg_attr(feature = "ffmpeg_7_0", path = "channel_layout.rs")]
+#[cfg_attr(not(feature = "ffmpeg_7_0"), path = "legacy_channel_layout.rs")]
+pub mod channel_layout;
 
 use std::ffi::CStr;
 use std::str::from_utf8_unchecked;

--- a/src/util/option/mod.rs
+++ b/src/util/option/mod.rs
@@ -23,7 +23,10 @@ pub enum Type {
     VideoRate,
     Duration,
     Color,
+    #[cfg(feature = "ffmpeg_5_1")]
     ChannelLayout,
+    #[cfg(feature = "ffmpeg_7_0")]
+    FlagArray,
     c_ulong,
     bool,
 }
@@ -53,6 +56,8 @@ impl From<AVOptionType> for Type {
             AV_OPT_TYPE_CHANNEL_LAYOUT => Type::ChannelLayout,
             #[cfg(feature = "ffmpeg_5_1")]
             AV_OPT_TYPE_CHLAYOUT => Type::ChannelLayout,
+            #[cfg(feature = "ffmpeg_7_0")]
+            AV_OPT_TYPE_FLAG_ARRAY => Type::FlagArray,
         }
     }
 }
@@ -79,7 +84,10 @@ impl From<Type> for AVOptionType {
             Type::VideoRate => AV_OPT_TYPE_VIDEO_RATE,
             Type::Duration => AV_OPT_TYPE_DURATION,
             Type::Color => AV_OPT_TYPE_COLOR,
-            Type::ChannelLayout => AV_OPT_TYPE_CHANNEL_LAYOUT,
+            #[cfg(feature = "ffmpeg_5_1")]
+            Type::ChannelLayout => AV_OPT_TYPE_CHLAYOUT,
+            #[cfg(feature = "ffmpeg_7_0")]
+            Type::FlagArray => AV_OPT_TYPE_FLAG_ARRAY,
         }
     }
 }

--- a/src/util/option/mod.rs
+++ b/src/util/option/mod.rs
@@ -53,7 +53,7 @@ impl From<AVOptionType> for Type {
             AV_OPT_TYPE_VIDEO_RATE => Type::VideoRate,
             AV_OPT_TYPE_DURATION => Type::Duration,
             AV_OPT_TYPE_COLOR => Type::Color,
-            #[cfg(not(feature = "ffmpeg_7_0"))]
+            #[cfg(all(feature = "ffmpeg_5_1", not(feature = "ffmpeg_7_0")))]
             AV_OPT_TYPE_CHANNEL_LAYOUT => Type::ChannelLayout,
             #[cfg(feature = "ffmpeg_5_1")]
             AV_OPT_TYPE_CHLAYOUT => Type::ChannelLayout,

--- a/src/util/option/mod.rs
+++ b/src/util/option/mod.rs
@@ -54,7 +54,7 @@ impl From<AVOptionType> for Type {
             AV_OPT_TYPE_COLOR => Type::Color,
             #[cfg(not(feature = "ffmpeg_7_0"))]
             AV_OPT_TYPE_CHANNEL_LAYOUT => Type::ChannelLayout,
-            #[cfg(feature = "ffmpeg_7_0")]
+            #[cfg(feature = "ffmpeg_5_1")]
             AV_OPT_TYPE_CHLAYOUT => Type::ChannelLayout,
             #[cfg(feature = "ffmpeg_7_0")]
             AV_OPT_TYPE_FLAG_ARRAY => Type::FlagArray,
@@ -85,7 +85,7 @@ impl From<Type> for AVOptionType {
             Type::Duration => AV_OPT_TYPE_DURATION,
             Type::Color => AV_OPT_TYPE_COLOR,
             #[cfg(not(feature = "ffmpeg_7_0"))]
-            Type::ChannelLayout => AV_OPT_TYPE_CHANNEL_LAYOUT ,
+            Type::ChannelLayout => AV_OPT_TYPE_CHANNEL_LAYOUT,
             #[cfg(feature = "ffmpeg_7_0")]
             Type::ChannelLayout => AV_OPT_TYPE_CHLAYOUT,
             #[cfg(feature = "ffmpeg_7_0")]

--- a/src/util/option/mod.rs
+++ b/src/util/option/mod.rs
@@ -23,7 +23,6 @@ pub enum Type {
     VideoRate,
     Duration,
     Color,
-    #[cfg(feature = "ffmpeg_5_1")]
     ChannelLayout,
     #[cfg(feature = "ffmpeg_7_0")]
     FlagArray,
@@ -53,9 +52,9 @@ impl From<AVOptionType> for Type {
             AV_OPT_TYPE_VIDEO_RATE => Type::VideoRate,
             AV_OPT_TYPE_DURATION => Type::Duration,
             AV_OPT_TYPE_COLOR => Type::Color,
-            #[cfg(all(feature = "ffmpeg_5_1", not(feature = "ffmpeg_7_0")))]
+            #[cfg(not(feature = "ffmpeg_7_0"))]
             AV_OPT_TYPE_CHANNEL_LAYOUT => Type::ChannelLayout,
-            #[cfg(feature = "ffmpeg_5_1")]
+            #[cfg(feature = "ffmpeg_7_0")]
             AV_OPT_TYPE_CHLAYOUT => Type::ChannelLayout,
             #[cfg(feature = "ffmpeg_7_0")]
             AV_OPT_TYPE_FLAG_ARRAY => Type::FlagArray,
@@ -85,7 +84,9 @@ impl From<Type> for AVOptionType {
             Type::VideoRate => AV_OPT_TYPE_VIDEO_RATE,
             Type::Duration => AV_OPT_TYPE_DURATION,
             Type::Color => AV_OPT_TYPE_COLOR,
-            #[cfg(feature = "ffmpeg_5_1")]
+            #[cfg(not(feature = "ffmpeg_7_0"))]
+            Type::ChannelLayout => AV_OPT_TYPE_CHANNEL_LAYOUT ,
+            #[cfg(feature = "ffmpeg_7_0")]
             Type::ChannelLayout => AV_OPT_TYPE_CHLAYOUT,
             #[cfg(feature = "ffmpeg_7_0")]
             Type::FlagArray => AV_OPT_TYPE_FLAG_ARRAY,

--- a/src/util/option/mod.rs
+++ b/src/util/option/mod.rs
@@ -53,6 +53,7 @@ impl From<AVOptionType> for Type {
             AV_OPT_TYPE_VIDEO_RATE => Type::VideoRate,
             AV_OPT_TYPE_DURATION => Type::Duration,
             AV_OPT_TYPE_COLOR => Type::Color,
+            #[cfg(not(feature = "ffmpeg_7_0"))]
             AV_OPT_TYPE_CHANNEL_LAYOUT => Type::ChannelLayout,
             #[cfg(feature = "ffmpeg_5_1")]
             AV_OPT_TYPE_CHLAYOUT => Type::ChannelLayout,

--- a/src/util/option/traits.rs
+++ b/src/util/option/traits.rs
@@ -134,12 +134,25 @@ pub trait Settable: Target {
         unsafe {
             let name = CString::new(name).unwrap();
 
-            check!(av_opt_set_channel_layout(
-                self.as_mut_ptr(),
-                name.as_ptr(),
-                layout.bits() as i64,
-                AV_OPT_SEARCH_CHILDREN
-            ))
+            #[cfg(not(feature = "ffmpeg_7_0"))]
+            {
+                check!(av_opt_set_channel_layout(
+                    self.as_mut_ptr(),
+                    name.as_ptr(),
+                    layout.bits() as i64,
+                    AV_OPT_SEARCH_CHILDREN
+                ))
+            }
+
+            #[cfg(feature = "ffmpeg_7_0")]
+            {
+                check!(av_opt_set_chlayout(
+                    self.as_mut_ptr(),
+                    name.as_ptr(),
+                    &layout.into(),
+                    AV_OPT_SEARCH_CHILDREN
+                ))
+            }
         }
     }
 }


### PR DESCRIPTION
This PR adds support for FFmpeg 7.0. Depends on https://github.com/zmwangx/rust-ffmpeg-sys/pull/72
Also, I wasn't able to find any easy way to install 7.0 in CI yet, so the CI is not updated

FFmpeg 7.0 removed a bunch of deprecated stuff, and the `ChannelLayout` is completely changed. I tried to implement new version in a least intrusive way.

Also, since it's a major version bump, could you please try to review and merge #164 for 7.0? These features (especially new_with_codec) are very much needed (judging by the amount of opened PRs, and I need them myself too) and they are simple enough that merging them should be in scope even though this crate is in maintenance mode only

Thank you