### PR TITLE
Fixes the transcoding example to work with ffmpeg 7

### DIFF
--- a/examples/transcode-x264.rs
+++ b/examples/transcode-x264.rs
@@ -30,7 +30,8 @@ const DEFAULT_X264_OPTS: &str = "preset=medium";
 struct Transcoder {
     ost_index: usize,
     decoder: decoder::Video,
-    encoder: encoder::video::Video,
+    input_time_base: Rational,
+    encoder: encoder::Video,
     logging_enabled: bool,
     frame_count: usize,
     last_log_frame_count: usize,
@@ -50,33 +51,34 @@ impl Transcoder {
         let decoder = ffmpeg::codec::context::Context::from_parameters(ist.parameters())?
             .decoder()
             .video()?;
-        let mut ost = octx.add_stream(encoder::find(codec::Id::H264))?;
-        let mut encoder = codec::context::Context::from_parameters(ost.parameters())?
+
+        let codec = encoder::find(codec::Id::H264);
+        let mut ost = octx.add_stream(codec)?;
+
+        let mut encoder = codec::context::Context::new_with_codec(codec.unwrap())
             .encoder()
             .video()?;
+        ost.set_parameters(&encoder);
         encoder.set_height(decoder.height());
         encoder.set_width(decoder.width());
         encoder.set_aspect_ratio(decoder.aspect_ratio());
         encoder.set_format(decoder.format());
         encoder.set_frame_rate(decoder.frame_rate());
-        encoder.set_time_base(decoder.frame_rate().unwrap().invert());
+        encoder.set_time_base(ist.time_base());
+
         if global_header {
             encoder.set_flags(codec::Flags::GLOBAL_HEADER);
         }
 
-        encoder
+        let opened_encoder = encoder
             .open_with(x264_opts)
-            .expect("error opening libx264 encoder with supplied settings");
-        encoder = codec::context::Context::from_parameters(ost.parameters())?
-            .encoder()
-            .video()?;
-        ost.set_parameters(&encoder);
+            .expect("error opening x264 with supplied settings");
+        ost.set_parameters(&opened_encoder);
         Ok(Self {
             ost_index,
             decoder,
-            encoder: codec::context::Context::from_parameters(ost.parameters())?
-                .encoder()
-                .video()?,
+            input_time_base: ist.time_base(),
+            encoder: opened_encoder,
             logging_enabled: enable_logging,
             frame_count: 0,
             last_log_frame_count: 0,
@@ -103,7 +105,7 @@ impl Transcoder {
             self.frame_count += 1;
             let timestamp = frame.timestamp();
             self.log_progress(f64::from(
-                Rational(timestamp.unwrap_or(0) as i32, 1) * self.decoder.time_base(),
+                Rational(timestamp.unwrap_or(0) as i32, 1) * self.input_time_base,
             ));
             frame.set_pts(timestamp);
             frame.set_kind(picture::Type::None);
@@ -128,7 +130,7 @@ impl Transcoder {
         let mut encoded = Packet::empty();
         while self.encoder.receive_packet(&mut encoded).is_ok() {
             encoded.set_stream(self.ost_index);
-            encoded.rescale_ts(self.decoder.time_base(), ost_time_base);
+            encoded.rescale_ts(self.input_time_base, ost_time_base);
             encoded.write_interleaved(octx).unwrap();
         }
     }
@@ -247,7 +249,6 @@ fn main() {
         let ost_time_base = ost_time_bases[ost_index as usize];
         match transcoders.get_mut(&ist_index) {
             Some(transcoder) => {
-                packet.rescale_ts(stream.time_base(), transcoder.decoder.time_base());
                 transcoder.send_packet_to_decoder(&packet);
                 transcoder.receive_and_process_decoded_frames(&mut octx, ost_time_base);
             }

--- a/examples/transcode-x264.rs
+++ b/examples/transcode-x264.rs
@@ -55,9 +55,10 @@ impl Transcoder {
         let codec = encoder::find(codec::Id::H264);
         let mut ost = octx.add_stream(codec)?;
 
-        let mut encoder = codec::context::Context::new_with_codec(codec.unwrap())
-            .encoder()
-            .video()?;
+        let mut encoder =
+            codec::context::Context::new_with_codec(codec.ok_or(ffmpeg::Error::InvalidData)?)
+                .encoder()
+                .video()?;
         ost.set_parameters(&encoder);
         encoder.set_height(decoder.height());
         encoder.set_width(decoder.width());


### PR DESCRIPTION
This PR fixes the transcode-x264 example to work, fixing the issues in #118. I've fixed:

1. We now initialize the encoder context from the codec.
2. The input time_base now comes from the stream instead of the decoder (decoder.time_base has been deprecated in ffmpeg since 2.5).
3. Uses the previously constructed encoder instead of recreating it unnecessarily.

I've tested this example on ffmpeg 6.6.1 (ubuntu 24.04), ffmpeg 4.4.2 (Ubuntu 22.04), ffmpeg 4.2.7 (Ubuntu 20.04), and ffmpeg 3.4.13.