### PR TITLE
Implement `Sample` for 8-channel packed format samples

### DIFF
--- a/src/util/frame/audio.rs
+++ b/src/util/frame/audio.rs
@@ -320,6 +320,13 @@ unsafe impl Sample for (u8, u8, u8, u8, u8, u8, u8) {
     }
 }
 
+unsafe impl Sample for (u8, u8, u8, u8, u8, u8, u8, u8) {
+    #[inline(always)]
+    fn is_valid(format: format::Sample, channels: u16) -> bool {
+        channels == 8 && format == format::Sample::U8(format::sample::Type::Packed)
+    }
+}
+
 unsafe impl Sample for i16 {
     #[inline(always)]
     fn is_valid(format: format::Sample, _channels: u16) -> bool {
@@ -366,6 +373,13 @@ unsafe impl Sample for (i16, i16, i16, i16, i16, i16, i16) {
     #[inline(always)]
     fn is_valid(format: format::Sample, channels: u16) -> bool {
         channels == 7 && format == format::Sample::I16(format::sample::Type::Packed)
+    }
+}
+
+unsafe impl Sample for (i16, i16, i16, i16, i16, i16, i16, i16) {
+    #[inline(always)]
+    fn is_valid(format: format::Sample, channels: u16) -> bool {
+        channels == 8 && format == format::Sample::I16(format::sample::Type::Packed)
     }
 }
 
@@ -418,6 +432,13 @@ unsafe impl Sample for (i32, i32, i32, i32, i32, i32, i32) {
     }
 }
 
+unsafe impl Sample for (i32, i32, i32, i32, i32, i32, i32, i32) {
+    #[inline(always)]
+    fn is_valid(format: format::Sample, channels: u16) -> bool {
+        channels == 8 && format == format::Sample::I32(format::sample::Type::Packed)
+    }
+}
+
 unsafe impl Sample for f32 {
     #[inline(always)]
     fn is_valid(format: format::Sample, _channels: u16) -> bool {
@@ -467,6 +488,13 @@ unsafe impl Sample for (f32, f32, f32, f32, f32, f32, f32) {
     }
 }
 
+unsafe impl Sample for (f32, f32, f32, f32, f32, f32, f32, f32) {
+    #[inline(always)]
+    fn is_valid(format: format::Sample, channels: u16) -> bool {
+        channels == 8 && format == format::Sample::F32(format::sample::Type::Packed)
+    }
+}
+
 unsafe impl Sample for f64 {
     #[inline(always)]
     fn is_valid(format: format::Sample, _channels: u16) -> bool {
@@ -513,5 +541,12 @@ unsafe impl Sample for (f64, f64, f64, f64, f64, f64, f64) {
     #[inline(always)]
     fn is_valid(format: format::Sample, channels: u16) -> bool {
         channels == 7 && format == format::Sample::F64(format::sample::Type::Packed)
+    }
+}
+
+unsafe impl Sample for (f64, f64, f64, f64, f64, f64, f64, f64) {
+    #[inline(always)]
+    fn is_valid(format: format::Sample, channels: u16) -> bool {
+        channels == 8 && format == format::Sample::F64(format::sample::Type::Packed)
     }
 }


### PR DESCRIPTION
Whilst using this library, I wanted to test my own code against [Dolby Demo Trailers](https://www.demolandia.net/cinema/dolby-demo-trailers-hd/page-10.html) which consist of videos containing 8-channel surround sound audio. However, I found that the `Sample` trait was not implemented for 8-channel packed samples. Seeing as 8-channel surround sound is evidently relevant out in the wild, we may as well implement `Sample` for 8-channel packed samples, too.