### PR TITLE
Make format::context::common::Context implement Sync trait

### DIFF
--- a/src/format/context/common.rs
+++ b/src/format/context/common.rs
@@ -14,6 +14,7 @@ pub struct Context {
 }
 
 unsafe impl Send for Context {}
+unsafe impl Sync for Context {}
 
 impl Context {
     pub unsafe fn wrap(ptr: *mut AVFormatContext, mode: destructor::Mode) -> Self {


### PR DESCRIPTION
This enables us to decode audio in async block in multi-threads async runtime.
I don't know whether it will break safety as it should be safe to use in different threads according to [this post](https://ffmpeg-user.ffmpeg.narkive.com/38FqvekO/libavcodec-libavformat-thread-safe).