### PR TITLE
Use threading in dump-frames.rs example

### DIFF
--- a/examples/dump-frames.rs
+++ b/examples/dump-frames.rs
@@ -18,8 +18,17 @@ fn main() -> Result<(), ffmpeg::Error> {
             .ok_or(ffmpeg::Error::StreamNotFound)?;
         let video_stream_index = input.index();
 
-        let context_decoder = ffmpeg::codec::context::Context::from_parameters(input.parameters())?;
+        let mut context_decoder = ffmpeg::codec::context::Context::from_parameters(input.parameters())?;
+        
+        if let Ok(parallelism) = std::thread::available_parallelism() {
+            context_decoder.set_threading(ffmpeg::threading::Config {
+                kind: ffmpeg::threading::Type::Frame,
+                count: parallelism.get(),
+            });
+        }
+
         let mut decoder = context_decoder.decoder().video()?;
+
 
         let mut scaler = Context::get(
             decoder.format(),


### PR DESCRIPTION
This significantly speeds up decoding with very little extra code. With the terse documentation, I think it's a good idea to expose that this is something one can do in an example.

Without this patch:
```
$ time cargo run -- vinny.mp4
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.06s
     Running `/home/architector4/.cache/cargo-builds/cargo-builds/debug/ffmpeg-example vinny.mp4`

real	0m14.942s
user	0m6.685s
sys	0m8.095s
```

With it:
```
$ time cargo run -- vinny.mp4
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.06s
     Running `/home/architector4/.cache/cargo-builds/cargo-builds/debug/ffmpeg-example vinny.mp4`

real	0m10.533s
user	0m9.327s
sys	0m8.823s
```