### PR TITLE
Determine resampler delay based on samples, not seconds

### DIFF
--- a/src/software/resampling/context.rs
+++ b/src/software/resampling/context.rs
@@ -149,12 +149,7 @@ impl Context {
 
     /// Get the remaining delay.
     pub fn delay(&self) -> Option<Delay> {
-        unsafe {
-            match swr_get_delay(self.as_ptr() as *mut _, 1) {
-                0 => None,
-                _ => Some(Delay::from(self)),
-            }
-        }
+        unsafe { Some(Delay::from(self)).filter(|d| d.output > 0) }
     }
 
     /// Run the resampler from the given input to the given output.


### PR DESCRIPTION
`resampling::Context::delay` currently returns None if the resampler delay is <1 second, which isn't entirely accurate as there could be milliseconds of samples left in the buffer.
I've changed the determination from reading the seconds of delay to the actual number of samples, so that `delay` won't return None until all samples have been read.