### PR TITLE
Fix segfaults when ptr is null

### DIFF
--- a/src/codec/audio.rs
+++ b/src/codec/audio.rs
@@ -76,6 +76,10 @@ impl Iterator for RateIter {
 
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
         unsafe {
+            if self.ptr.is_null() {
+              return None;
+            }
+
             if *self.ptr == 0 {
                 return None;
             }
@@ -103,6 +107,10 @@ impl Iterator for FormatIter {
 
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
         unsafe {
+            if self.ptr.is_null() {
+              return None;
+            }
+
             if *self.ptr == AVSampleFormat::AV_SAMPLE_FMT_NONE {
                 return None;
             }

--- a/src/codec/codec.rs
+++ b/src/codec/codec.rs
@@ -118,6 +118,10 @@ impl Iterator for ProfileIter {
 
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
         unsafe {
+            if self.ptr.is_null() {
+              return None;
+            }
+
             if (*self.ptr).profile == FF_PROFILE_UNKNOWN {
                 return None;
             }

--- a/src/codec/packet/packet.rs
+++ b/src/codec/packet/packet.rs
@@ -318,6 +318,10 @@ impl<'a> Iterator for SideDataIter<'a> {
 
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
         unsafe {
+            if self.ptr.is_null() {
+              return None;
+            }
+
             if self.cur >= (*self.ptr).side_data_elems {
                 None
             } else {

--- a/src/codec/video.rs
+++ b/src/codec/video.rs
@@ -60,6 +60,10 @@ impl Iterator for RateIter {
 
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
         unsafe {
+            if self.ptr.is_null() {
+              return None;
+            }
+
             if (*self.ptr).num == 0 && (*self.ptr).den == 0 {
                 return None;
             }
@@ -87,6 +91,10 @@ impl Iterator for FormatIter {
 
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
         unsafe {
+            if self.ptr.is_null() {
+              return None;
+            }
+
             if *self.ptr == AVPixelFormat::AV_PIX_FMT_NONE {
                 return None;
             }

--- a/src/filter/filter.rs
+++ b/src/filter/filter.rs
@@ -103,7 +103,7 @@ impl<'a> Iterator for PadIter<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         unsafe {
-            if self.cur >= self.count {
+            if self.cur >= self.count || self.ptr.is_null() {
                 return None;
             }
 


### PR DESCRIPTION
As described in https://github.com/zmwangx/rust-ffmpeg/issues/225, I added checks for null pointers.

Although the issue recommended the checks to be in the `new()` methods, I decided it's more appropriate to put them directly before the segfault would occur. This allows for more flexibility, as creating the iterator with a null pointer might have some valid use cases. However, please correct me if I’m wrong.

Also, I found another segfault in `packet::packet::SideDataIter`. I haven't found any others. I also did not fix any segfaults that only occurred in unsafe code.