### PR TITLE
fix: apply patch mentioned in zmwangx#246

### DIFF
--- a/src/codec/packet/side_data.rs
+++ b/src/codec/packet/side_data.rs
@@ -55,6 +55,10 @@ pub enum Type {
     #[cfg(feature = "ffmpeg_5_0")]
     DYNAMIC_HDR10_PLUS,
 
+    #[cfg(feature = "ffmpeg_6_0")]
+    EXIF,
+
+
     #[cfg(feature = "ffmpeg_7_0")]
     IAMF_MIX_GAIN_PARAM,
     #[cfg(feature = "ffmpeg_7_0")]
@@ -125,6 +129,9 @@ impl From<AVPacketSideDataType> for Type {
 
             #[cfg(feature = "ffmpeg_5_0")]
             AV_PKT_DATA_DYNAMIC_HDR10_PLUS => Type::DYNAMIC_HDR10_PLUS,
+
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_PKT_DATA_EXIF => Type::EXIF,
 
             #[cfg(feature = "ffmpeg_7_0")]
             AV_PKT_DATA_IAMF_MIX_GAIN_PARAM => Type::IAMF_MIX_GAIN_PARAM,
@@ -198,6 +205,9 @@ impl From<Type> for AVPacketSideDataType {
 
             #[cfg(feature = "ffmpeg_5_0")]
             Type::DYNAMIC_HDR10_PLUS => AV_PKT_DATA_DYNAMIC_HDR10_PLUS,
+
+            #[cfg(feature = "ffmpeg_6_0")]
+            Type::EXIF => AV_PKT_DATA_EXIF,
 
             #[cfg(feature = "ffmpeg_7_0")]
             Type::IAMF_MIX_GAIN_PARAM => AV_PKT_DATA_IAMF_MIX_GAIN_PARAM,

--- a/src/util/frame/side_data.rs
+++ b/src/util/frame/side_data.rs
@@ -62,6 +62,9 @@ pub enum Type {
     #[cfg(feature = "ffmpeg_6_0")]
     AMBIENT_VIEWING_ENVIRONMENT,
 
+    #[cfg(feature = "ffmpeg_6_0")]
+    EXIF,
+
     #[cfg(feature = "ffmpeg_6_1")]
     VIDEO_HINT,
 
@@ -138,6 +141,9 @@ impl From<AVFrameSideDataType> for Type {
             #[cfg(feature = "ffmpeg_6_0")]
             AV_FRAME_DATA_AMBIENT_VIEWING_ENVIRONMENT => Type::AMBIENT_VIEWING_ENVIRONMENT,
 
+            #[cfg(feature = "ffmpeg_6_0")]
+            AV_FRAME_DATA_EXIF => Type::EXIF,
+
             #[cfg(feature = "ffmpeg_6_1")]
             AV_FRAME_DATA_VIDEO_HINT => Type::VIDEO_HINT,
 
@@ -206,6 +212,9 @@ impl From<Type> for AVFrameSideDataType {
 
             #[cfg(feature = "ffmpeg_6_0")]
             Type::AMBIENT_VIEWING_ENVIRONMENT => AV_FRAME_DATA_AMBIENT_VIEWING_ENVIRONMENT,
+
+            #[cfg(feature = "ffmpeg_6_0")]
+            Type::EXIF => AV_FRAME_DATA_EXIF,
 
             #[cfg(feature = "ffmpeg_6_1")]
             Type::VIDEO_HINT => AV_FRAME_DATA_VIDEO_HINT,


### PR DESCRIPTION
This PR adds `side_data::Type`, with patch mentioned in #246 .

fyi:
```toml
ffmpeg-next = { git = "https://github.com/sevenc-nanashi/rust-ffmpeg", branch = "feat/8.0-fix" }
```