### PR TITLE
Implement custom stream IO

### DIFF
--- a/src/format/context/destructor.rs
+++ b/src/format/context/destructor.rs
@@ -1,9 +1,12 @@
+use super::StreamIo;
 use ffi::*;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Debug)]
 pub enum Mode {
     Input,
     Output,
+    InputCustomIo(StreamIo),
+    OutputCustomIo(StreamIo),
 }
 
 pub struct Destructor {
@@ -21,6 +24,14 @@ impl Drop for Destructor {
     fn drop(&mut self) {
         unsafe {
             match self.mode {
+                Mode::InputCustomIo(ref _io) => {
+                    avformat_close_input(&mut self.ptr);
+                    // Custom io will just be dropped here
+                }
+                Mode::OutputCustomIo(ref _io) => {
+                    avformat_free_context(self.ptr);
+                    // Custom io will just be dropped here
+                }
                 Mode::Input => avformat_close_input(&mut self.ptr),
 
                 Mode::Output => {

--- a/src/format/context/destructor.rs
+++ b/src/format/context/destructor.rs
@@ -24,13 +24,17 @@ impl Drop for Destructor {
     fn drop(&mut self) {
         unsafe {
             match self.mode {
-                Mode::InputCustomIo(ref _io) => {
+                Mode::InputCustomIo(_) => {
+                    // AVFMT_FLAG_CUSTOM_IO is set, so this leaves `pb` alone
+                    // (demuxers' read_close() may still use it); the StreamIo
+                    // in `mode` frees it when dropped after this body.
                     avformat_close_input(&mut self.ptr);
-                    // Custom io will just be dropped here
                 }
-                Mode::OutputCustomIo(ref _io) => {
+                Mode::OutputCustomIo(_) => {
                     avformat_free_context(self.ptr);
-                    // Custom io will just be dropped here
+                    // The StreamIo in `mode` is dropped afterwards; its Drop
+                    // flushes buffered data to the stream before freeing the
+                    // AVIOContext.
                 }
                 Mode::Input => avformat_close_input(&mut self.ptr),
 

--- a/src/format/context/input.rs
+++ b/src/format/context/input.rs
@@ -24,6 +24,15 @@ impl Input {
             ctx: Context::wrap(ptr, destructor::Mode::Input),
         }
     }
+    pub unsafe fn wrap_with_custom_io(
+        ptr: *mut AVFormatContext,
+        custom_io: format::context::StreamIo,
+    ) -> Self {
+        Input {
+            ptr,
+            ctx: Context::wrap(ptr, destructor::Mode::InputCustomIo(custom_io)),
+        }
+    }
 
     pub unsafe fn as_ptr(&self) -> *const AVFormatContext {
         self.ptr as *const _

--- a/src/format/context/mod.rs
+++ b/src/format/context/mod.rs
@@ -7,6 +7,9 @@ pub use self::input::Input;
 pub mod output;
 pub use self::output::Output;
 
+pub mod stream_io;
+pub use self::stream_io::StreamIo;
+
 #[doc(hidden)]
 pub mod common;
 

--- a/src/format/context/output.rs
+++ b/src/format/context/output.rs
@@ -25,6 +25,15 @@ impl Output {
             ctx: Context::wrap(ptr, destructor::Mode::Output),
         }
     }
+    pub unsafe fn wrap_with_custom_io(
+        ptr: *mut AVFormatContext,
+        custom_io: format::context::StreamIo,
+    ) -> Self {
+        Output {
+            ptr,
+            ctx: Context::wrap(ptr, destructor::Mode::OutputCustomIo(custom_io)),
+        }
+    }
 
     pub unsafe fn as_ptr(&self) -> *const AVFormatContext {
         self.ptr as *const _

--- a/src/format/context/stream_io.rs
+++ b/src/format/context/stream_io.rs
@@ -1,0 +1,198 @@
+use ffi;
+use std::ffi::{c_int, c_void};
+use std::io::{Read, Seek, SeekFrom, Write};
+use Error;
+
+/// Default internal I/O buffer size used by the underlying `AVIOContext`.
+const BUFFER_SIZE: usize = 16384;
+
+/// A safe Rust wrapper that creates an FFmpeg [`AVIOContext`] backed by any
+/// Rust `Read` / `Write` / `Seek` stream.
+///
+/// This type allocates and owns an `AVIOContext` whose callbacks bridge to a
+/// user-provided Rust stream. The stream is boxed and stored in the `opaque`
+/// field of `AVIOContext` and is automatically dropped when `StreamIo` is
+/// dropped.
+///
+/// # What this is for
+///
+/// FFmpeg allows you to supply custom I/O by passing an `AVIOContext` to
+/// demuxers/muxers instead of a filename/URL. `StreamIo` lets you do that
+/// with ordinary Rust I/O types like `File`, `Cursor<Vec<u8>>`, network
+/// streams, etc.
+///
+/// # Ownership & lifetime
+///
+/// - `StreamIo` **owns** both the C `AVIOContext` and the boxed Rust stream.
+/// - Dropping `StreamIo` frees the internal buffer, the `AVIOContext`,
+///   and the boxed stream in the correct order.
+/// - You must ensure the `AVIOContext*` returned by [`StreamIo::as_mut_ptr`]
+///   does not outlive the `StreamIo` that created it.
+///
+/// # Thread-safety
+///
+/// The underlying Rust stream is not synchronized; callbacks are invoked
+/// by FFmpeg on the calling thread. Do not share the same `StreamIo`
+/// across threads unless the wrapped stream itself is thread-safe and FFmpeg
+/// will not call the callbacks concurrently.
+///
+/// # EOF
+///
+/// - A `Read` that returns `Ok(0)` is translated to `AVERROR_EOF`.
+///
+/// # Safety notes
+///
+/// - `as_mut_ptr` exposes a raw `*mut AVIOContext` for integration with FFmpeg C APIs.
+///   You must make sure this pointer does not outlive the `StreamIo` instance.
+///
+/// [`AVIOContext`]: https://ffmpeg.org/doxygen/trunk/structAVIOContext.html
+pub struct StreamIo {
+    ptr: *mut ffi::AVIOContext,
+    drop_opaque: fn(*mut c_void),
+}
+impl StreamIo {
+    pub fn from_read<T: Read>(stream: T) -> Result<Self, Error> {
+        Self::new_impl(stream, Some(read::<T>), None, None)
+    }
+    pub fn from_read_seek<T: Read + Seek>(stream: T) -> Result<Self, Error> {
+        Self::new_impl(stream, Some(read::<T>), None, Some(seek::<T>))
+    }
+    pub fn from_read_write_seek<T: Read + Write + Seek>(stream: T) -> Result<Self, Error> {
+        Self::new_impl(stream, Some(read::<T>), Some(write::<T>), Some(seek::<T>))
+    }
+    pub fn from_read_write<T: Read + Write>(stream: T) -> Result<Self, Error> {
+        Self::new_impl(stream, Some(read::<T>), Some(write::<T>), None)
+    }
+    pub fn from_write<T: Write>(stream: T) -> Result<Self, Error> {
+        Self::new_impl(stream, None, Some(write::<T>), None)
+    }
+    pub fn from_write_seek<T: Write + Seek>(stream: T) -> Result<Self, Error> {
+        Self::new_impl(stream, None, Some(write::<T>), Some(seek::<T>))
+    }
+
+    fn new_impl<T>(
+        stream: T,
+        r: Option<unsafe extern "C" fn(*mut c_void, *mut u8, c_int) -> c_int>,
+        w: Option<unsafe extern "C" fn(*mut c_void, *const u8, c_int) -> c_int>,
+        s: Option<unsafe extern "C" fn(*mut c_void, i64, c_int) -> i64>,
+    ) -> Result<Self, Error> {
+        let buffer = unsafe { ffi::av_malloc(BUFFER_SIZE) };
+        if buffer.is_null() {
+            return Err(Error::Other { errno: ffi::ENOMEM });
+        }
+        let stream_box_ptr = Box::into_raw(Box::new(stream)) as *mut c_void;
+        let ptr = unsafe {
+            ffi::avio_alloc_context(
+                buffer as *mut _,
+                BUFFER_SIZE as _,
+                w.is_some() as _,
+                stream_box_ptr,
+                r,
+                w,
+                s,
+            )
+        };
+        if ptr.is_null() {
+            unsafe {
+                drop(Box::from_raw(stream_box_ptr as *mut T));
+            }
+            return Err(Error::Other { errno: ffi::ENOMEM });
+        }
+
+        fn drop_box<T>(p: *mut c_void) {
+            drop(unsafe { Box::from_raw(p as *mut T) });
+        }
+        Ok(Self {
+            ptr,
+            drop_opaque: drop_box::<T>,
+        })
+    }
+
+    /// Returns a mutable raw pointer to the underlying `AVIOContext`.
+    ///
+    /// # Safety
+    /// The returned pointer is owned by `self`. Do **not** free it or mutate its
+    /// `buffer`/`opaque` fields directly. It must not outlive `self`.
+    pub fn as_mut_ptr(&mut self) -> *mut ffi::AVIOContext {
+        self.ptr
+    }
+}
+
+impl Drop for StreamIo {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() {
+            unsafe {
+                let opaque = (*self.ptr).opaque;
+                ffi::av_freep(&raw mut (*self.ptr).buffer as *mut c_void);
+                ffi::avio_context_free(&mut self.ptr);
+                (self.drop_opaque)(opaque);
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for StreamIo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StreamIo").field("ptr", &self.ptr).finish()
+    }
+}
+
+unsafe extern "C" fn read<T: Read>(opaque: *mut c_void, buf: *mut u8, buf_size: c_int) -> c_int {
+    let buf = unsafe { std::slice::from_raw_parts_mut(buf, buf_size as usize) };
+    let stream = unsafe { &mut *(opaque as *mut T) };
+    match stream.read(buf) {
+        Ok(0) => ffi::AVERROR_EOF,
+        Ok(n) => n as c_int,
+        Err(e) => map_io_error(e),
+    }
+}
+unsafe extern "C" fn write<T: Write>(
+    opaque: *mut c_void,
+    buf: *const u8,
+    buf_size: c_int,
+) -> c_int {
+    let buf = unsafe { std::slice::from_raw_parts(buf, buf_size as usize) };
+    let stream = unsafe { &mut *(opaque as *mut T) };
+    match stream.write(buf) {
+        Ok(n) => n as c_int,
+        Err(e) => map_io_error(e),
+    }
+}
+unsafe extern "C" fn seek<T: Seek>(opaque: *mut c_void, offset: i64, whence: c_int) -> i64 {
+    let stream = unsafe { &mut *(opaque as *mut T) };
+
+    if whence == ffi::AVSEEK_SIZE {
+        // Return stream size
+        match stream.stream_position().and_then(|cur| {
+            let end = stream.seek(SeekFrom::End(0))?;
+            if cur != end {
+                stream.seek(SeekFrom::Start(cur))?;
+            }
+            Ok(end)
+        }) {
+            Ok(sz) => return sz as i64,
+            Err(_) => return ffi::AVERROR(ffi::ENOSYS) as i64,
+        }
+    }
+
+    let pos = match whence {
+        0 => SeekFrom::Start(offset as u64),
+        1 => SeekFrom::Current(offset),
+        2 => SeekFrom::End(offset),
+        _ => return ffi::AVERROR(ffi::EINVAL) as i64,
+    };
+    match stream.seek(pos) {
+        Ok(pos) => pos as i64,
+        Err(_) => ffi::AVERROR(ffi::EIO) as i64,
+    }
+}
+
+fn map_io_error(e: std::io::Error) -> i32 {
+    use std::io::ErrorKind::*;
+    match e.kind() {
+        UnexpectedEof => ffi::AVERROR_EOF,
+        Interrupted => ffi::AVERROR(ffi::EINTR),
+        WouldBlock | TimedOut => ffi::AVERROR(ffi::EAGAIN),
+        _ => ffi::AVERROR(ffi::EIO),
+    }
+}

--- a/src/format/context/stream_io.rs
+++ b/src/format/context/stream_io.rs
@@ -1,6 +1,7 @@
 use ffi;
 use libc;
 use std::any::TypeId;
+use std::convert::TryFrom;
 use std::ffi::{c_int, c_void};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::mem::ManuallyDrop;
@@ -286,6 +287,12 @@ unsafe extern "C" fn write<T: Write>(
 unsafe extern "C" fn seek<T: Seek>(opaque: *mut c_void, offset: i64, whence: c_int) -> i64 {
     let stream = unsafe { &mut *(opaque as *mut T) };
 
+    // AVSEEK_FORCE may be OR'd into `whence` ("seek by any means"); avio.h
+    // documents it as ignored by the seek code since 2010, and FFmpeg's own
+    // dispatchers mask it off before seeking (`avio_seek`, `ffurl_seek`).
+    // Honor the flag convention instead of failing the seek with EINVAL.
+    let whence = whence & !ffi::AVSEEK_FORCE;
+
     if whence == ffi::AVSEEK_SIZE {
         // Return the stream size. Any negative return makes `avio_size` fall
         // back to probing with SEEK_END, which also restores the position
@@ -297,21 +304,32 @@ unsafe extern "C" fn seek<T: Seek>(opaque: *mut c_void, offset: i64, whence: c_i
             }
             Ok(end)
         }) {
-            Ok(sz) => return sz as i64,
+            Ok(sz) => return position_to_i64(sz),
             Err(e) => return map_io_error(e) as i64,
         }
     }
 
     let pos = match whence {
-        0 => SeekFrom::Start(offset as u64),
+        // `avio_seek` rejects negative absolute offsets before invoking the
+        // callback, so one can only arrive from a caller driving the callback
+        // directly; `as u64` would turn it into a huge forward seek.
+        0 if offset >= 0 => SeekFrom::Start(offset as u64),
+        0 => return ffi::AVERROR(ffi::EINVAL) as i64,
         1 => SeekFrom::Current(offset),
         2 => SeekFrom::End(offset),
         _ => return ffi::AVERROR(ffi::EINVAL) as i64,
     };
     match stream.seek(pos) {
-        Ok(pos) => pos as i64,
+        Ok(pos) => position_to_i64(pos),
         Err(e) => map_io_error(e) as i64,
     }
+}
+
+// `Seek` reports positions as `u64`, but the callback returns `i64` with
+// negative values reserved for AVERROR codes; a position above `i64::MAX`
+// would wrap into (or alias) an error code.
+fn position_to_i64(pos: u64) -> i64 {
+    i64::try_from(pos).unwrap_or(ffi::AVERROR(libc::EOVERFLOW) as i64)
 }
 
 // Not a C callback: invoked from `StreamIo::drop` to flush the user stream

--- a/src/format/context/stream_io.rs
+++ b/src/format/context/stream_io.rs
@@ -1,82 +1,145 @@
 use ffi;
+use libc;
+use std::any::TypeId;
 use std::ffi::{c_int, c_void};
 use std::io::{Read, Seek, SeekFrom, Write};
+use std::mem::ManuallyDrop;
 use Error;
 
-/// Default internal I/O buffer size used by the underlying `AVIOContext`.
-const BUFFER_SIZE: usize = 16384;
+/// Default `AVIOContext` buffer size, matching libavformat's own default.
+const DEFAULT_BUFFER_SIZE: usize = 32768;
 
-/// A safe Rust wrapper that creates an FFmpeg [`AVIOContext`] backed by any
-/// Rust `Read` / `Write` / `Seek` stream.
+/// An FFmpeg [`AVIOContext`] backed by a Rust `Read`/`Write`/`Seek` stream,
+/// for custom I/O via `format::input_from_stream` / `format::output_to_stream`.
 ///
-/// This type allocates and owns an `AVIOContext` whose callbacks bridge to a
-/// user-provided Rust stream. The stream is boxed and stored in the `opaque`
-/// field of `AVIOContext` and is automatically dropped when `StreamIo` is
-/// dropped.
+/// `StreamIo` owns both the `AVIOContext` and the boxed stream; dropping it
+/// frees both. The stream must be `Send + 'static` (the callbacks may run on
+/// whatever thread is driving the context), but not `Sync`: callbacks never
+/// run concurrently.
 ///
-/// # What this is for
+/// A context is unidirectional: [`StreamIo::from_read`] /
+/// [`StreamIo::from_read_seek`] create read (demuxing) contexts,
+/// [`StreamIo::from_write`] / [`StreamIo::from_write_seek`] write (muxing)
+/// contexts; a mismatch is rejected with `EINVAL`.
 ///
-/// FFmpeg allows you to supply custom I/O by passing an `AVIOContext` to
-/// demuxers/muxers instead of a filename/URL. `StreamIo` lets you do that
-/// with ordinary Rust I/O types like `File`, `Cursor<Vec<u8>>`, network
-/// streams, etc.
+/// I/O is buffered internally (32 KiB by default; tune it with the
+/// `*_with_capacity` constructors). The stream must be *blocking*: FFmpeg has
+/// no retry layer for custom I/O, so the first `WouldBlock`/`TimedOut` error
+/// poisons the context. `Interrupted` is retried internally, and `Ok(0)` from
+/// `read` is reported as EOF.
 ///
-/// # Ownership & lifetime
-///
-/// - `StreamIo` **owns** both the C `AVIOContext` and the boxed Rust stream.
-/// - Dropping `StreamIo` frees the internal buffer, the `AVIOContext`,
-///   and the boxed stream in the correct order.
-/// - You must ensure the `AVIOContext*` returned by [`StreamIo::as_mut_ptr`]
-///   does not outlive the `StreamIo` that created it.
-///
-/// # Thread-safety
-///
-/// The underlying Rust stream is not synchronized; callbacks are invoked
-/// by FFmpeg on the calling thread. Do not share the same `StreamIo`
-/// across threads unless the wrapped stream itself is thread-safe and FFmpeg
-/// will not call the callbacks concurrently.
-///
-/// # EOF
-///
-/// - A `Read` that returns `Ok(0)` is translated to `AVERROR_EOF`.
-///
-/// # Safety notes
-///
-/// - `as_mut_ptr` exposes a raw `*mut AVIOContext` for integration with FFmpeg C APIs.
-///   You must make sure this pointer does not outlive the `StreamIo` instance.
+/// Dropping a writable `StreamIo` — directly, or via the `Output` that
+/// absorbed it — flushes buffered data and the stream itself, discarding
+/// errors (like `std::io::BufWriter`). For well-formed output you must still
+/// call `write_trailer` first. Use [`StreamIo::into_inner`] to get the
+/// stream back.
 ///
 /// [`AVIOContext`]: https://ffmpeg.org/doxygen/trunk/structAVIOContext.html
 pub struct StreamIo {
     ptr: *mut ffi::AVIOContext,
     drop_opaque: fn(*mut c_void),
+    flush_opaque: Option<fn(*mut c_void)>,
+    stream_type: TypeId,
 }
+
+// SAFETY: every constructor requires the wrapped stream to be `Send`, the
+// `AVIOContext` and its buffer are heap allocations not tied to any thread,
+// and the stream is only ever accessed through `&mut self` / the callbacks
+// (which FFmpeg invokes from the single thread driving the I/O). This impl is
+// also what the pre-existing `unsafe impl Send` on `Input`/`Output`/`Context`
+// relies on, since they embed a `StreamIo` via `destructor::Mode`.
+unsafe impl Send for StreamIo {}
+
 impl StreamIo {
-    pub fn from_read<T: Read>(stream: T) -> Result<Self, Error> {
-        Self::new_impl(stream, Some(read::<T>), None, None)
+    pub fn from_read<T: Read + Send + 'static>(stream: T) -> Result<Self, Error> {
+        Self::from_read_with_capacity(stream, DEFAULT_BUFFER_SIZE)
     }
-    pub fn from_read_seek<T: Read + Seek>(stream: T) -> Result<Self, Error> {
-        Self::new_impl(stream, Some(read::<T>), None, Some(seek::<T>))
+    pub fn from_read_seek<T: Read + Seek + Send + 'static>(stream: T) -> Result<Self, Error> {
+        Self::from_read_seek_with_capacity(stream, DEFAULT_BUFFER_SIZE)
     }
-    pub fn from_read_write_seek<T: Read + Write + Seek>(stream: T) -> Result<Self, Error> {
-        Self::new_impl(stream, Some(read::<T>), Some(write::<T>), Some(seek::<T>))
+    pub fn from_write<T: Write + Send + 'static>(stream: T) -> Result<Self, Error> {
+        Self::from_write_with_capacity(stream, DEFAULT_BUFFER_SIZE)
     }
-    pub fn from_read_write<T: Read + Write>(stream: T) -> Result<Self, Error> {
-        Self::new_impl(stream, Some(read::<T>), Some(write::<T>), None)
-    }
-    pub fn from_write<T: Write>(stream: T) -> Result<Self, Error> {
-        Self::new_impl(stream, None, Some(write::<T>), None)
-    }
-    pub fn from_write_seek<T: Write + Seek>(stream: T) -> Result<Self, Error> {
-        Self::new_impl(stream, None, Some(write::<T>), Some(seek::<T>))
+    pub fn from_write_seek<T: Write + Seek + Send + 'static>(stream: T) -> Result<Self, Error> {
+        Self::from_write_seek_with_capacity(stream, DEFAULT_BUFFER_SIZE)
     }
 
-    fn new_impl<T>(
+    /// Like [`StreamIo::from_read`], with an explicit buffer size in bytes.
+    /// Fails with `EINVAL` if `capacity` is zero or exceeds `c_int::MAX`.
+    pub fn from_read_with_capacity<T: Read + Send + 'static>(
         stream: T,
+        capacity: usize,
+    ) -> Result<Self, Error> {
+        Self::new_impl(stream, capacity, Some(read::<T>), None, None, None)
+    }
+    /// Like [`StreamIo::from_read_seek`], with an explicit buffer size in bytes.
+    /// Fails with `EINVAL` if `capacity` is zero or exceeds `c_int::MAX`.
+    pub fn from_read_seek_with_capacity<T: Read + Seek + Send + 'static>(
+        stream: T,
+        capacity: usize,
+    ) -> Result<Self, Error> {
+        Self::new_impl(
+            stream,
+            capacity,
+            Some(read::<T>),
+            None,
+            Some(seek::<T>),
+            None,
+        )
+    }
+    /// Like [`StreamIo::from_write`], with an explicit buffer size in bytes.
+    /// Fails with `EINVAL` if `capacity` is zero or exceeds `c_int::MAX`.
+    pub fn from_write_with_capacity<T: Write + Send + 'static>(
+        stream: T,
+        capacity: usize,
+    ) -> Result<Self, Error> {
+        Self::new_impl(
+            stream,
+            capacity,
+            None,
+            Some(write::<T>),
+            None,
+            Some(flush_stream::<T>),
+        )
+    }
+    /// Like [`StreamIo::from_write_seek`], with an explicit buffer size in bytes.
+    /// Fails with `EINVAL` if `capacity` is zero or exceeds `c_int::MAX`.
+    pub fn from_write_seek_with_capacity<T: Write + Seek + Send + 'static>(
+        stream: T,
+        capacity: usize,
+    ) -> Result<Self, Error> {
+        Self::new_impl(
+            stream,
+            capacity,
+            None,
+            Some(write::<T>),
+            Some(seek::<T>),
+            Some(flush_stream::<T>),
+        )
+    }
+
+    /// Returns `true` if this is a write (muxing) context.
+    pub fn is_writable(&self) -> bool {
+        unsafe { (*self.ptr).write_flag != 0 }
+    }
+
+    fn new_impl<T: Send + 'static>(
+        stream: T,
+        capacity: usize,
         r: Option<unsafe extern "C" fn(*mut c_void, *mut u8, c_int) -> c_int>,
         w: Option<unsafe extern "C" fn(*mut c_void, WriteBufferType, c_int) -> c_int>,
         s: Option<unsafe extern "C" fn(*mut c_void, i64, c_int) -> i64>,
+        flush: Option<fn(*mut c_void)>,
     ) -> Result<Self, Error> {
-        let buffer = unsafe { ffi::av_malloc(BUFFER_SIZE) };
+        // `AVIOContext::buffer_size` is a C `int`, and a zero-size buffer
+        // would make `fill_buffer` / `flush_buffer` spin without progress.
+        if capacity == 0 || capacity > c_int::MAX as usize {
+            return Err(Error::Other { errno: ffi::EINVAL });
+        }
+        // Zero-initialized so the slice handed to the first `read` callback
+        // never exposes uninitialized memory (see the zeroing in `read` for
+        // the buffers FFmpeg itself allocates and swaps in later).
+        let buffer = unsafe { ffi::av_mallocz(capacity) };
         if buffer.is_null() {
             return Err(Error::Other { errno: ffi::ENOMEM });
         }
@@ -84,7 +147,7 @@ impl StreamIo {
         let ptr = unsafe {
             ffi::avio_alloc_context(
                 buffer as *mut _,
-                BUFFER_SIZE as _,
+                capacity as _,
                 w.is_some() as _,
                 stream_box_ptr,
                 r,
@@ -93,19 +156,39 @@ impl StreamIo {
             )
         };
         if ptr.is_null() {
+            // `avio_alloc_context` takes ownership of `buffer` only on success.
             unsafe {
+                ffi::av_free(buffer);
                 drop(Box::from_raw(stream_box_ptr as *mut T));
             }
             return Err(Error::Other { errno: ffi::ENOMEM });
         }
 
-        fn drop_box<T>(p: *mut c_void) {
-            drop(unsafe { Box::from_raw(p as *mut T) });
-        }
         Ok(Self {
             ptr,
             drop_opaque: drop_box::<T>,
+            flush_opaque: flush,
+            stream_type: TypeId::of::<T>(),
         })
+    }
+
+    /// Consumes the `StreamIo` and returns the wrapped stream, flushing data
+    /// still buffered in the `AVIOContext` first. The stream's own
+    /// [`Write::flush`] is *not* called, so the caller can flush and observe
+    /// errors. Fails (returning `self`) unless `T` is the exact type the
+    /// `StreamIo` was constructed with.
+    pub fn into_inner<T: 'static>(self) -> Result<T, Self> {
+        if self.stream_type != TypeId::of::<T>() {
+            return Err(self);
+        }
+        let mut this = ManuallyDrop::new(self);
+        unsafe {
+            ffi::avio_flush(this.ptr);
+            let opaque = (*this.ptr).opaque;
+            ffi::av_freep(&raw mut (*this.ptr).buffer as *mut c_void);
+            ffi::avio_context_free(&mut this.ptr);
+            Ok(*Box::from_raw(opaque as *mut T))
+        }
     }
 
     /// Returns a mutable raw pointer to the underlying `AVIOContext`.
@@ -123,6 +206,17 @@ impl Drop for StreamIo {
         if !self.ptr.is_null() {
             unsafe {
                 let opaque = (*self.ptr).opaque;
+                if (*self.ptr).write_flag != 0 {
+                    // Salvage data still buffered in the AVIOContext, then let
+                    // the stream flush its own buffers (a user `BufWriter`
+                    // tail would otherwise only flush in its Drop, or be lost).
+                    // Errors are unreportable from a destructor and are
+                    // discarded, like `std::io::BufWriter` does.
+                    ffi::avio_flush(self.ptr);
+                    if let Some(flush) = self.flush_opaque {
+                        flush(opaque);
+                    }
+                }
                 ffi::av_freep(&raw mut (*self.ptr).buffer as *mut c_void);
                 ffi::avio_context_free(&mut self.ptr);
                 (self.drop_opaque)(opaque);
@@ -138,12 +232,35 @@ impl std::fmt::Debug for StreamIo {
 }
 
 unsafe extern "C" fn read<T: Read>(opaque: *mut c_void, buf: *mut u8, buf_size: c_int) -> c_int {
+    // FFmpeg never issues zero-sized reads (and `read_packet` must not
+    // return 0 — it asserts on that), but a `Read` impl would report one as
+    // `Ok(0)`, which we translate to EOF; reject instead of lying.
+    if buf_size <= 0 {
+        return ffi::AVERROR(ffi::EINVAL);
+    }
+    // `buf` routinely points into uninitialized memory FFmpeg allocated: the
+    // probe buffer `ffio_rewind_with_probe_data` swaps in as `s->buffer`, the
+    // post-probe `set_buf_size` reallocation, and direct reads into caller
+    // buffers all come from plain `av_malloc`/`av_realloc`. A safe `Read`
+    // impl is allowed to read from the slice it is given, so it must be
+    // initialized; the memset is noise next to the I/O itself.
+    unsafe { std::ptr::write_bytes(buf, 0, buf_size as usize) };
     let buf = unsafe { std::slice::from_raw_parts_mut(buf, buf_size as usize) };
     let stream = unsafe { &mut *(opaque as *mut T) };
-    match stream.read(buf) {
-        Ok(0) => ffi::AVERROR_EOF,
-        Ok(n) => n as c_int,
-        Err(e) => map_io_error(e),
+    loop {
+        return match stream.read(buf) {
+            Ok(0) => ffi::AVERROR_EOF,
+            // A buggy (but safe) `Read` impl may report more bytes than the buffer
+            // holds; FFmpeg trusts the count and would advance `buf_end` past the
+            // allocation.
+            Ok(n) if n > buf.len() => ffi::AVERROR(ffi::EIO),
+            Ok(n) => n as c_int,
+            // Retry interrupted reads like FFmpeg's own protocol layer does;
+            // surfacing EINTR would poison the context (see `map_io_error`)
+            // even though the read can simply be reissued.
+            Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(e) => map_io_error(e),
+        };
     }
 }
 unsafe extern "C" fn write<T: Write>(
@@ -151,10 +268,18 @@ unsafe extern "C" fn write<T: Write>(
     buf: WriteBufferType,
     buf_size: c_int,
 ) -> c_int {
+    if buf_size < 0 {
+        return ffi::AVERROR(ffi::EINVAL);
+    }
     let buf = unsafe { std::slice::from_raw_parts(buf, buf_size as usize) };
     let stream = unsafe { &mut *(opaque as *mut T) };
-    match stream.write(buf) {
-        Ok(n) => n as c_int,
+    // FFmpeg treats any non-negative return as "the whole buffer was written"
+    // and never retries a remainder, so a short `write` would silently lose
+    // data; `write_all` is the only faithful mapping. It also retries
+    // `ErrorKind::Interrupted` internally (per its contract), so EINTR never
+    // reaches `map_io_error` — mirroring the retry loop in `read`.
+    match stream.write_all(buf) {
+        Ok(()) => buf_size,
         Err(e) => map_io_error(e),
     }
 }
@@ -162,7 +287,9 @@ unsafe extern "C" fn seek<T: Seek>(opaque: *mut c_void, offset: i64, whence: c_i
     let stream = unsafe { &mut *(opaque as *mut T) };
 
     if whence == ffi::AVSEEK_SIZE {
-        // Return stream size
+        // Return the stream size. Any negative return makes `avio_size` fall
+        // back to probing with SEEK_END, which also restores the position
+        // FFmpeg expects, so a partial failure here cannot corrupt state.
         match stream.stream_position().and_then(|cur| {
             let end = stream.seek(SeekFrom::End(0))?;
             if cur != end {
@@ -171,7 +298,7 @@ unsafe extern "C" fn seek<T: Seek>(opaque: *mut c_void, offset: i64, whence: c_i
             Ok(end)
         }) {
             Ok(sz) => return sz as i64,
-            Err(_) => return ffi::AVERROR(ffi::ENOSYS) as i64,
+            Err(e) => return map_io_error(e) as i64,
         }
     }
 
@@ -183,17 +310,55 @@ unsafe extern "C" fn seek<T: Seek>(opaque: *mut c_void, offset: i64, whence: c_i
     };
     match stream.seek(pos) {
         Ok(pos) => pos as i64,
-        Err(_) => ffi::AVERROR(ffi::EIO) as i64,
+        Err(e) => map_io_error(e) as i64,
     }
+}
+
+// Not a C callback: invoked from `StreamIo::drop` to flush the user stream
+// after the `AVIOContext` buffer has been written out.
+fn flush_stream<T: Write>(opaque: *mut c_void) {
+    let _ = unsafe { &mut *(opaque as *mut T) }.flush();
+}
+
+// Not a C callback: invoked from `StreamIo::drop` to free the boxed stream.
+// `opaque` must be the `Box<T>` created in `new_impl`.
+fn drop_box<T>(opaque: *mut c_void) {
+    drop(unsafe { Box::from_raw(opaque as *mut T) });
 }
 
 fn map_io_error(e: std::io::Error) -> i32 {
     use std::io::ErrorKind::*;
+    // On Unix the raw OS error *is* an errno value, which is exactly what
+    // AVERROR encodes; pass it through to preserve detail (EACCES, ENOSPC,
+    // ...). On Windows it is a Win32 error code, not an errno, so it cannot
+    // be used and we fall back to mapping the `ErrorKind`.
+    #[cfg(unix)]
+    if let Some(errno) = e.raw_os_error() {
+        if errno > 0 {
+            return ffi::AVERROR(errno);
+        }
+    }
+    // Errors returned from the read/write callbacks are sticky: there is no
+    // retry layer above a custom AVIOContext (FFmpeg retries EINTR/EAGAIN
+    // only inside its own URL protocols), so `fill_buffer`/`writeout` latch
+    // whatever we return into `s->error` and no further I/O happens. That is
+    // why `Interrupted` is retried in the callbacks instead of being mapped
+    // here (this arm stays reachable from `seek`, which FFmpeg does not
+    // treat as sticky), and why `WouldBlock`/`TimedOut` — while given their
+    // truthful codes — are fatal: see the "Blocking I/O" notes on `StreamIo`.
+    //
+    // The errno constants come from `libc`, not the generated bindings: they
+    // must agree with the `util::error` re-exports users match `Error::Other`
+    // against (and with the platform CRT the FFmpeg binary itself was built
+    // with), whereas bindgen has been observed emitting glibc values on
+    // Windows (ETIMEDOUT 110 vs the CRT's 138).
     match e.kind() {
         UnexpectedEof => ffi::AVERROR_EOF,
-        Interrupted => ffi::AVERROR(ffi::EINTR),
-        WouldBlock | TimedOut => ffi::AVERROR(ffi::EAGAIN),
-        _ => ffi::AVERROR(ffi::EIO),
+        Interrupted => ffi::AVERROR(libc::EINTR),
+        WouldBlock => ffi::AVERROR(libc::EAGAIN),
+        TimedOut => ffi::AVERROR(libc::ETIMEDOUT),
+        Unsupported => ffi::AVERROR(libc::ENOSYS),
+        _ => ffi::AVERROR(libc::EIO),
     }
 }
 

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -234,20 +234,15 @@ pub fn input_from_stream(
         (*ps).pb = custom_io.as_mut_ptr();
 
         let filename = filename.map(|f| CString::new(f).unwrap());
-        let filename_ptr = filename.as_ref().map_or(std::ptr::null(), |f| f.as_ptr());
+        let filename_ptr = filename.as_ref().map_or(ptr::null(), |f| f.as_ptr());
 
         let result = if let Some(opts) = options {
             let mut opts = opts.disown();
-            let res = avformat_open_input(&mut ps, filename_ptr, std::ptr::null(), &mut opts);
+            let res = avformat_open_input(&mut ps, filename_ptr, ptr::null_mut(), &mut opts);
             Dictionary::own(opts);
             res
         } else {
-            avformat_open_input(
-                &mut ps,
-                filename_ptr,
-                std::ptr::null(),
-                std::ptr::null_mut(),
-            )
+            avformat_open_input(&mut ps, filename_ptr, ptr::null_mut(), ptr::null_mut())
         };
 
         match result {
@@ -390,10 +385,10 @@ pub fn output_to_stream(
         let mut ps = ptr::null_mut();
 
         let filename = filename.map(|f| CString::new(f).unwrap());
-        let filename_ptr = filename.as_ref().map_or(std::ptr::null(), |f| f.as_ptr());
+        let filename_ptr = filename.as_ref().map_or(ptr::null(), |f| f.as_ptr());
 
         let format = format.map(|f| CString::new(f).unwrap());
-        let format_ptr = format.as_ref().map_or(std::ptr::null(), |f| f.as_ptr());
+        let format_ptr = format.as_ref().map_or(ptr::null(), |f| f.as_ptr());
 
         match avformat_alloc_output_context2(&mut ps, ptr::null_mut(), format_ptr, filename_ptr) {
             0 => {

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -62,6 +62,12 @@ fn from_path<P: AsRef<Path> + ?Sized>(path: &P) -> CString {
     CString::new(path.as_ref().as_os_str().to_str().unwrap()).unwrap()
 }
 
+fn opt_cstring(s: Option<&str>) -> Result<Option<CString>, Error> {
+    s.map(CString::new)
+        .transpose()
+        .map_err(|_| Error::Other { errno: EINVAL })
+}
+
 // NOTE: this will be better with specialization or anonymous return types
 pub fn open<P: AsRef<Path> + ?Sized>(path: &P, format: &Format) -> Result<Context, Error> {
     unsafe {
@@ -202,6 +208,9 @@ where
 {
     unsafe {
         let mut ps = avformat_alloc_context();
+        if ps.is_null() {
+            return Err(Error::Other { errno: ENOMEM });
+        }
         let path = from_path(path);
         (*ps).interrupt_callback = interrupt::new(Box::new(closure)).interrupt;
 
@@ -219,22 +228,31 @@ where
     }
 }
 
-/// Opens an input file using a custom I/O stream.
-/// Create `format::context::StreamIo` first, then pass to this function.
+/// Opens an input from a readable `context::StreamIo` (created with
+/// `StreamIo::from_read` or `StreamIo::from_read_seek`).
 ///
-/// You can optionally include a filename to help with format detection,
-/// and a dictionary of options to configure the format context.
+/// An optional filename helps with format detection; options configure the
+/// format context. Fails with `EINVAL` if `custom_io` is a write context or
+/// `filename` contains an interior NUL byte.
 pub fn input_from_stream(
     mut custom_io: context::StreamIo,
     filename: Option<&str>,
     options: Option<Dictionary>,
 ) -> Result<context::Input, Error> {
+    if custom_io.is_writable() {
+        return Err(Error::Other { errno: EINVAL });
+    }
+
+    let filename = opt_cstring(filename)?;
+    let filename_ptr = filename.as_ref().map_or(ptr::null(), |f| f.as_ptr());
+
     unsafe {
         let mut ps = avformat_alloc_context();
+        if ps.is_null() {
+            return Err(Error::Other { errno: ENOMEM });
+        }
         (*ps).pb = custom_io.as_mut_ptr();
-
-        let filename = filename.map(|f| CString::new(f).unwrap());
-        let filename_ptr = filename.as_ref().map_or(ptr::null(), |f| f.as_ptr());
+        (*ps).flags |= AVFMT_FLAG_CUSTOM_IO;
 
         let result = if let Some(opts) = options {
             let mut opts = opts.disown();
@@ -371,28 +389,37 @@ pub fn output_as_with<P: AsRef<Path> + ?Sized>(
     }
 }
 
-/// Creates the output context where the result is written to the provided Stream.
-/// Create a writable `format::context::StreamIo` first, then pass to this function.
+/// Creates an output context that writes to a writable `context::StreamIo`
+/// (created with `StreamIo::from_write` or `StreamIo::from_write_seek`).
 ///
-/// You can optionally include a filename to infer the output format from that,
-/// or specify the format explicitly.
+/// The output format is inferred from `filename` or given explicitly via
+/// `format`; most muxers need a seekable stream for well-formed output. Call
+/// `write_trailer` before dropping the returned context — dropping only
+/// flushes what the muxer already emitted, it cannot finalize the file.
+/// Fails with `EINVAL` if `custom_io` is not a write context or `filename` /
+/// `format` contain an interior NUL byte.
 pub fn output_to_stream(
     mut custom_io: context::StreamIo,
     filename: Option<&str>,
     format: Option<&str>,
 ) -> Result<context::Output, Error> {
+    if !custom_io.is_writable() {
+        return Err(Error::Other { errno: EINVAL });
+    }
+
+    let filename = opt_cstring(filename)?;
+    let filename_ptr = filename.as_ref().map_or(ptr::null(), |f| f.as_ptr());
+
+    let format = opt_cstring(format)?;
+    let format_ptr = format.as_ref().map_or(ptr::null(), |f| f.as_ptr());
+
     unsafe {
         let mut ps = ptr::null_mut();
-
-        let filename = filename.map(|f| CString::new(f).unwrap());
-        let filename_ptr = filename.as_ref().map_or(ptr::null(), |f| f.as_ptr());
-
-        let format = format.map(|f| CString::new(f).unwrap());
-        let format_ptr = format.as_ref().map_or(ptr::null(), |f| f.as_ptr());
 
         match avformat_alloc_output_context2(&mut ps, ptr::null_mut(), format_ptr, filename_ptr) {
             0 => {
                 (*ps).pb = custom_io.as_mut_ptr();
+                (*ps).flags |= AVFMT_FLAG_CUSTOM_IO;
 
                 Ok(context::Output::wrap_with_custom_io(ps, custom_io))
             }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -396,8 +396,10 @@ pub fn output_as_with<P: AsRef<Path> + ?Sized>(
 /// `format`; most muxers need a seekable stream for well-formed output. Call
 /// `write_trailer` before dropping the returned context — dropping only
 /// flushes what the muxer already emitted, it cannot finalize the file.
-/// Fails with `EINVAL` if `custom_io` is not a write context or `filename` /
-/// `format` contain an interior NUL byte.
+/// Fails with `EINVAL` if `custom_io` is not a write context, if `filename` /
+/// `format` contain an interior NUL byte, or if the resolved muxer does its
+/// own I/O and would never write to the stream (`AVFMT_NOFILE` formats like
+/// `image2` or output devices).
 pub fn output_to_stream(
     mut custom_io: context::StreamIo,
     filename: Option<&str>,
@@ -418,6 +420,15 @@ pub fn output_to_stream(
 
         match avformat_alloc_output_context2(&mut ps, ptr::null_mut(), format_ptr, filename_ptr) {
             0 => {
+                // AVFMT_NOFILE muxers (image2's one-file-per-frame, devices,
+                // ...) do their own I/O, and `AVFormatContext.pb` is
+                // documented to stay NULL for them; the caller's stream would
+                // silently never receive the muxed output.
+                if (*(*ps).oformat).flags & AVFMT_NOFILE != 0 {
+                    avformat_free_context(ps);
+                    return Err(Error::Other { errno: EINVAL });
+                }
+
                 (*ps).pb = custom_io.as_mut_ptr();
                 (*ps).flags |= AVFMT_FLAG_CUSTOM_IO;
 

--- a/tests/stream_io.rs
+++ b/tests/stream_io.rs
@@ -1,0 +1,248 @@
+extern crate ffmpeg_next;
+
+use ffmpeg_next::format::context::{Input, Output, StreamIo};
+use ffmpeg_next::{format, Error};
+use std::io::Cursor;
+
+fn assert_send<T: Send>() {}
+
+#[test]
+fn stream_io_and_contexts_are_send() {
+    assert_send::<StreamIo>();
+    assert_send::<Input>();
+    assert_send::<Output>();
+}
+
+#[test]
+fn into_inner_roundtrip() {
+    let io = StreamIo::from_write_seek(Cursor::new(vec![1u8, 2, 3])).unwrap();
+
+    // Wrong type: StreamIo is handed back unchanged.
+    let io = io.into_inner::<Vec<u8>>().unwrap_err();
+
+    // Exact construction type: the stream comes back out.
+    let cursor = io.into_inner::<Cursor<Vec<u8>>>().expect("type matches");
+    assert_eq!(cursor.into_inner(), vec![1, 2, 3]);
+}
+
+fn assert_einval<T>(result: Result<T, Error>) {
+    let einval = Error::Other {
+        errno: ffmpeg_next::util::error::EINVAL,
+    };
+    match result {
+        Err(e) => assert_eq!(e, einval),
+        Ok(_) => panic!("expected EINVAL, got Ok"),
+    }
+}
+
+#[test]
+fn invalid_capacity_is_rejected() {
+    assert_einval(StreamIo::from_read_with_capacity(Cursor::new(vec![0u8]), 0));
+    assert_einval(StreamIo::from_write_with_capacity(
+        Vec::new(),
+        i32::MAX as usize + 1,
+    ));
+}
+
+#[test]
+fn custom_capacity_roundtrip() {
+    let io = StreamIo::from_write_seek_with_capacity(Cursor::new(Vec::new()), 4096).unwrap();
+    let cursor = io.into_inner::<Cursor<Vec<u8>>>().expect("type matches");
+    assert_eq!(cursor.into_inner(), Vec::<u8>::new());
+}
+
+#[test]
+fn direction_mismatch_is_rejected() {
+    // A write context must not be usable for demuxing.
+    let w = StreamIo::from_write(Vec::new()).unwrap();
+    assert_einval(format::input_from_stream(w, None, None));
+
+    // A read context must not be usable for muxing.
+    let r = StreamIo::from_read(Cursor::new(vec![0u8])).unwrap();
+    assert_einval(format::output_to_stream(r, None, Some("matroska")));
+}
+
+#[test]
+fn interior_nul_names_error_instead_of_panicking() {
+    let r = StreamIo::from_read(Cursor::new(vec![0u8])).unwrap();
+    assert_einval(format::input_from_stream(r, Some("bad\0name.mp4"), None));
+
+    let w = StreamIo::from_write(Vec::new()).unwrap();
+    assert_einval(format::output_to_stream(w, Some("bad\0name.mp4"), None));
+}
+
+/// A minimal but valid WAV file (PCM s16le, mono, 8 kHz) with `data_len`
+/// bytes of payload, every payload byte non-zero.
+fn tiny_wav(data_len: usize) -> Vec<u8> {
+    let mut wav = Vec::with_capacity(44 + data_len);
+    wav.extend_from_slice(b"RIFF");
+    wav.extend_from_slice(&(36 + data_len as u32).to_le_bytes());
+    wav.extend_from_slice(b"WAVE");
+    wav.extend_from_slice(b"fmt ");
+    wav.extend_from_slice(&16u32.to_le_bytes());
+    wav.extend_from_slice(&1u16.to_le_bytes()); // PCM
+    wav.extend_from_slice(&1u16.to_le_bytes()); // mono
+    wav.extend_from_slice(&8000u32.to_le_bytes()); // sample rate
+    wav.extend_from_slice(&16000u32.to_le_bytes()); // byte rate
+    wav.extend_from_slice(&2u16.to_le_bytes()); // block align
+    wav.extend_from_slice(&16u16.to_le_bytes()); // bits per sample
+    wav.extend_from_slice(b"data");
+    wav.extend_from_slice(&(data_len as u32).to_le_bytes());
+    wav.extend((0..data_len).map(|i| (i % 255) as u8 + 1));
+    wav
+}
+
+#[test]
+fn interrupted_reads_are_retried() {
+    use std::io::Read;
+
+    // Yields `ErrorKind::Interrupted` twice before every successful read.
+    // FFmpeg has no retry layer above a custom AVIOContext, so unless the
+    // wrapper retries these itself, the very first one becomes a sticky
+    // error and the open fails.
+    struct Interrupting<R> {
+        inner: R,
+        countdown: u32,
+    }
+    impl<R: Read> Read for Interrupting<R> {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            if self.countdown > 0 {
+                self.countdown -= 1;
+                return Err(std::io::ErrorKind::Interrupted.into());
+            }
+            self.countdown = 2;
+            self.inner.read(buf)
+        }
+    }
+
+    let reader = Interrupting {
+        inner: Cursor::new(tiny_wav(8192)),
+        countdown: 2,
+    };
+    let mut input = format::input_from_stream(StreamIo::from_read(reader).unwrap(), None, None)
+        .expect("interrupted reads must be retried, not surfaced");
+    assert_eq!(input.streams().count(), 1);
+    assert!(input.packets().count() > 0);
+}
+
+#[test]
+fn read_buffer_is_handed_to_the_stream_zeroed() {
+    use std::io::{Read, Seek, SeekFrom};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    // FFmpeg hands the read callback buffers that may be freshly allocated
+    // (probe buffers, internal reallocations) or hold stale bytes from
+    // earlier fills; the wrapper promises the stream a zeroed slice. A panic
+    // would unwind across the C callback boundary, so record violations and
+    // assert afterwards.
+    struct ZeroCheck {
+        inner: Cursor<Vec<u8>>,
+        dirty: Arc<AtomicBool>,
+    }
+    impl Read for ZeroCheck {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            if !buf.iter().all(|&b| b == 0) {
+                self.dirty.store(true, Ordering::SeqCst);
+            }
+            self.inner.read(buf)
+        }
+    }
+    impl Seek for ZeroCheck {
+        fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+            self.inner.seek(pos)
+        }
+    }
+
+    let dirty = Arc::new(AtomicBool::new(false));
+    // Large enough that the AVIOContext buffer is refilled (and wrapped)
+    // several times after probing, with every payload byte non-zero.
+    let reader = ZeroCheck {
+        inner: Cursor::new(tiny_wav(200_000)),
+        dirty: Arc::clone(&dirty),
+    };
+    let mut input =
+        format::input_from_stream(StreamIo::from_read_seek(reader).unwrap(), None, None).unwrap();
+    assert!(input.packets().count() > 0);
+    assert!(
+        !dirty.load(Ordering::SeqCst),
+        "read callback saw a non-zeroed buffer"
+    );
+}
+
+#[test]
+fn nonblocking_and_timed_out_streams_poison_the_context() {
+    use std::io::Read;
+
+    struct Failing(std::io::ErrorKind);
+    impl Read for Failing {
+        fn read(&mut self, _: &mut [u8]) -> std::io::Result<usize> {
+            Err(self.0.into())
+        }
+    }
+
+    // No retry layer above a custom AVIOContext: the first failure is
+    // sticky and surfaces from the open with its truthful errno. The errno
+    // must match the `util::error` re-exports users compare against.
+    for (kind, errno) in [
+        (
+            std::io::ErrorKind::WouldBlock,
+            ffmpeg_next::util::error::EAGAIN,
+        ),
+        (
+            std::io::ErrorKind::TimedOut,
+            ffmpeg_next::util::error::ETIMEDOUT,
+        ),
+    ] {
+        let io = StreamIo::from_read(Failing(kind)).unwrap();
+        match format::input_from_stream(io, None, None) {
+            Err(e) => assert_eq!(e, Error::Other { errno }),
+            Ok(_) => panic!("expected the open to fail"),
+        }
+    }
+}
+
+#[test]
+fn custom_io_flag_is_set_on_both_contexts() {
+    use ffmpeg_next::ffi::AVFMT_FLAG_CUSTOM_IO;
+
+    let input = format::input_from_stream(
+        StreamIo::from_read_seek(Cursor::new(tiny_wav(4096))).unwrap(),
+        None,
+        None,
+    )
+    .unwrap();
+    assert_ne!(unsafe { (*input.as_ptr()).flags } & AVFMT_FLAG_CUSTOM_IO, 0);
+
+    let output = format::output_to_stream(
+        StreamIo::from_write_seek(Cursor::new(Vec::new())).unwrap(),
+        None,
+        Some("wav"),
+    )
+    .unwrap();
+    assert_ne!(
+        unsafe { (*output.as_ptr()).flags } & AVFMT_FLAG_CUSTOM_IO,
+        0
+    );
+}
+
+#[test]
+fn writable_stream_is_flushed_on_drop() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    struct FlushTracker(Arc<AtomicBool>);
+    impl std::io::Write for FlushTracker {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            self.0.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    let flushed = Arc::new(AtomicBool::new(false));
+    drop(StreamIo::from_write(FlushTracker(Arc::clone(&flushed))).unwrap());
+    assert!(flushed.load(Ordering::SeqCst));
+}

--- a/tests/stream_io.rs
+++ b/tests/stream_io.rs
@@ -63,6 +63,78 @@ fn direction_mismatch_is_rejected() {
 }
 
 #[test]
+fn nofile_muxers_are_rejected() {
+    // image2 (AVFMT_NOFILE) opens one file per frame through its own I/O;
+    // `AVFormatContext.pb` is documented to stay NULL for such muxers, so a
+    // caller-provided stream would silently never receive the output.
+    let w = StreamIo::from_write_seek(Cursor::new(Vec::new())).unwrap();
+    assert_einval(format::output_to_stream(
+        w,
+        Some("frame-%03d.bmp"),
+        Some("image2"),
+    ));
+}
+
+/// Drives the seek callback installed in the `AVIOContext` the way FFmpeg
+/// (or a caller invoking `AVIOContext.seek` directly) would.
+fn raw_seek(io: &mut StreamIo, offset: i64, whence: i32) -> i64 {
+    unsafe {
+        let ctx = io.as_mut_ptr();
+        ((*ctx).seek.expect("seekable context"))((*ctx).opaque, offset, whence)
+    }
+}
+
+#[test]
+fn seek_masks_avseek_force() {
+    use ffmpeg_next::ffi::{AVSEEK_FORCE, AVSEEK_SIZE};
+
+    let mut io = StreamIo::from_read_seek(Cursor::new(vec![0u8; 10])).unwrap();
+    // SEEK_SET is 0, so this whence is SEEK_SET | AVSEEK_FORCE.
+    assert_eq!(raw_seek(&mut io, 7, AVSEEK_FORCE), 7);
+    assert_eq!(raw_seek(&mut io, -2, 2 | AVSEEK_FORCE), 8);
+    assert_eq!(raw_seek(&mut io, 0, AVSEEK_SIZE | AVSEEK_FORCE), 10);
+    // SEEK_CUR: AVSEEK_SIZE must have restored the position.
+    assert_eq!(raw_seek(&mut io, 0, 1), 8);
+}
+
+#[test]
+fn seek_rejects_negative_absolute_offsets_and_unknown_whence() {
+    let einval = ffmpeg_next::ffi::AVERROR(ffmpeg_next::util::error::EINVAL) as i64;
+
+    let mut io = StreamIo::from_read_seek(Cursor::new(vec![0u8; 10])).unwrap();
+    assert_eq!(raw_seek(&mut io, -1, 0), einval);
+    assert_eq!(raw_seek(&mut io, i64::MIN, 0), einval);
+    assert_eq!(raw_seek(&mut io, 0, 3), einval);
+    // SEEK_CUR: the failed seeks must not have moved the stream.
+    assert_eq!(raw_seek(&mut io, 0, 1), 0);
+}
+
+#[test]
+fn unrepresentable_positions_are_eoverflow() {
+    use std::io::{Read, Seek, SeekFrom};
+
+    // A `Seek` impl is free to report positions `i64` cannot hold; the
+    // callback must turn those into an error instead of letting them wrap
+    // into the negative AVERROR range.
+    struct Huge;
+    impl Read for Huge {
+        fn read(&mut self, _: &mut [u8]) -> std::io::Result<usize> {
+            Ok(0)
+        }
+    }
+    impl Seek for Huge {
+        fn seek(&mut self, _: SeekFrom) -> std::io::Result<u64> {
+            Ok(u64::MAX)
+        }
+    }
+
+    let eoverflow = ffmpeg_next::ffi::AVERROR(ffmpeg_next::util::error::EOVERFLOW) as i64;
+    let mut io = StreamIo::from_read_seek(Huge).unwrap();
+    assert_eq!(raw_seek(&mut io, 0, 1), eoverflow);
+    assert_eq!(raw_seek(&mut io, 0, ffmpeg_next::ffi::AVSEEK_SIZE), eoverflow);
+}
+
+#[test]
 fn interior_nul_names_error_instead_of_panicking() {
     let r = StreamIo::from_read(Cursor::new(vec![0u8])).unwrap();
     assert_einval(format::input_from_stream(r, Some("bad\0name.mp4"), None));

--- a/tests/stream_io.rs
+++ b/tests/stream_io.rs
@@ -131,7 +131,10 @@ fn unrepresentable_positions_are_eoverflow() {
     let eoverflow = ffmpeg_next::ffi::AVERROR(ffmpeg_next::util::error::EOVERFLOW) as i64;
     let mut io = StreamIo::from_read_seek(Huge).unwrap();
     assert_eq!(raw_seek(&mut io, 0, 1), eoverflow);
-    assert_eq!(raw_seek(&mut io, 0, ffmpeg_next::ffi::AVSEEK_SIZE), eoverflow);
+    assert_eq!(
+        raw_seek(&mut io, 0, ffmpeg_next::ffi::AVSEEK_SIZE),
+        eoverflow
+    );
 }
 
 #[test]


### PR DESCRIPTION
This PR adds a way to create inputs and outputs by providing a standard Rust Read/Write/Seek streams.

It allows using ffmpeg with arbitrary data sources like filesystem, network, memory etc

examples:

```rust
let file = std::fs::File::open("test.mp4")?;
let input_ctx = format::input_from_stream(format::context::StreamIo::from_read_seek(file)?, None, None)?;
```

```rust
let mut vec = Vec::new();
let mut cursor = std::io::Cursor::new(&mut vec);
let mut output_ctx = format::output_to_stream(format::context::StreamIo::from_write_seek(cursor)?, None, Some("mp4")).unwrap();
```