### PR TITLE
Fix `Packet::write*` rejecting zero-sized packets that carry side data

### DIFF
--- a/src/codec/packet/packet.rs
+++ b/src/codec/packet/packet.rs
@@ -17,6 +17,11 @@ impl Packet {
     pub unsafe fn is_empty(&self) -> bool {
         self.0.size == 0
     }
+
+    #[inline(always)]
+    fn lacks_payload_and_side_data(&self) -> bool {
+        self.0.size == 0 && self.0.side_data_elems == 0
+    }
 }
 
 impl Packet {
@@ -226,7 +231,9 @@ impl Packet {
     #[inline]
     pub fn write(&self, format: &mut format::context::Output) -> Result<bool, Error> {
         unsafe {
-            if self.is_empty() {
+            // FFmpeg allows zero-size packets that still carry side data, such as
+            // FLAC encoder flush packets with AV_PKT_DATA_NEW_EXTRADATA.
+            if self.lacks_payload_and_side_data() {
                 return Err(Error::InvalidData);
             }
 
@@ -241,7 +248,9 @@ impl Packet {
     #[inline]
     pub fn write_interleaved(&self, format: &mut format::context::Output) -> Result<(), Error> {
         unsafe {
-            if self.is_empty() {
+            // Keep wrapper behavior aligned with av_interleaved_write_frame():
+            // zero-size packets are still valid when they only carry side data.
+            if self.lacks_payload_and_side_data() {
                 return Err(Error::InvalidData);
             }
 
@@ -335,6 +344,28 @@ impl<'a> Iterator for SideDataIter<'a> {
 
             (length - self.cur as usize, Some(length - self.cur as usize))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Packet;
+
+    #[test]
+    fn empty_packet_without_side_data_is_still_empty_for_write_checks() {
+        let packet = Packet::empty();
+
+        assert!(unsafe { packet.is_empty() });
+        assert!(packet.lacks_payload_and_side_data());
+    }
+
+    #[test]
+    fn zero_sized_packet_with_side_data_is_not_treated_as_invalid_empty_packet() {
+        let mut packet = Packet::empty();
+        packet.0.side_data_elems = 1;
+
+        assert!(unsafe { packet.is_empty() });
+        assert!(!packet.lacks_payload_and_side_data());
     }
 }
 


### PR DESCRIPTION
`Packet::write()` and `Packet::write_interleaved()` currently return
`Error::InvalidData` whenever `packet.size == 0`.

That is stricter than FFmpeg's own `av_write_frame()` /
`av_interleaved_write_frame()` behavior. FFmpeg allows packets with no payload
data as long as they still carry side data. One real example is the FLAC
encoder flush path, which can emit a zero-sized packet containing
`AV_PKT_DATA_NEW_EXTRADATA` so the muxer can update the final STREAMINFO block.

With the current wrapper behavior, those packets are rejected before they ever
reach FFmpeg, which makes otherwise valid FLAC muxing fail from Rust.

This patch changes the pre-check so only packets that have neither payload nor
side data are rejected. Zero-sized packets with side data are now forwarded to
FFmpeg, matching the underlying C API semantics more closely.

Also included:
- a small helper to express the new condition
- unit tests covering:
  - empty packet without side data is still rejected by the wrapper pre-check
  - zero-sized packet with side data is not treated as invalid