### PR TITLE
fix: input_with_interrupt's closure must be 'static

### DIFF
--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -198,7 +198,7 @@ pub fn input_with_interrupt<P: AsRef<Path> + ?Sized, F>(
     closure: F,
 ) -> Result<context::Input, Error>
 where
-    F: FnMut() -> bool,
+    F: FnMut() -> bool + 'static,
 {
     unsafe {
         let mut ps = avformat_alloc_context();
@@ -210,6 +210,38 @@ where
                 r if r >= 0 => Ok(context::Input::wrap(ps)),
                 e => {
                     avformat_close_input(&mut ps);
+                    Err(Error::from(e))
+                }
+            },
+
+            e => Err(Error::from(e)),
+        }
+    }
+}
+
+pub fn input_with_interrupt_and_dictionary<F>(
+    path: &Path,
+    closure: F,
+    options: Dictionary,
+) -> Result<context::Input, Error>
+where
+    F: FnMut() -> bool + 'static,
+{
+    unsafe {
+        let mut ps = avformat_alloc_context();
+        (*ps).interrupt_callback = interrupt::new(Box::new(closure)).interrupt;
+        let path = from_path(path);
+
+        let mut opts = options.disown();
+        let res =
+            avformat_open_input(&raw mut ps, path.as_ptr(), ptr::null_mut(), &raw mut opts);
+        Dictionary::own(opts);
+
+        match res {
+            0 => match avformat_find_stream_info(ps, ptr::null_mut()) {
+                r if r >= 0 => Ok(context::Input::wrap(ps)),
+                e => {
+                    avformat_close_input(&raw mut ps);
                     Err(Error::from(e))
                 }
             },

--- a/src/util/interrupt.rs
+++ b/src/util/interrupt.rs
@@ -22,7 +22,7 @@ where
 
 pub fn new<F>(opaque: Box<F>) -> Interrupt
 where
-    F: FnMut() -> bool,
+    F: FnMut() -> bool + 'static,
 {
     let interrupt_cb = AVIOInterruptCB {
         callback: Some(callback::<F>),


### PR DESCRIPTION
TL;DR: Because the library hangs onto the closue, callers can't temporarily borrow values inside the closure, they have to `move` their values inside.  This also adds a new `format::input_with_interrupt_and_dictionary` which is a combination of `format::input_with_interrupt` and `format::input_with_dictionary`.

I had some code that looked like this:

```rust
            let mut ictx = ffmpeg_utils::input_with_interrupt_and_dictionary(
                Path::new(&self.stream_config.url),                
                || {
                    if self.cancel_token.is_cancelled() {
                        info!("Cancellation requested, stopping read");
                        return true; // Return 1 to indicate interruption
                    }
                    false // Return 0 to continue reading
                },
                opts,
            )?
```

And it was segfaulting, which Rust is supposed to avoid.  :P  The problem here is that we have this closure that borrows `self`.  Since the closure isn't `'static`, that's fine; the compiler assumes we're only borrowing `self` for the duration of the `input_with_interrupt_and_dictionary` function call.  But, this isn't true; `input_with_interrupt_and_dictionary` and `input_with_interrupt` hang on to that closure indefinitely.  This means in my case when I canceled the token, `self` was dropped, and then at some point later the closure ran and tried to access the now-freed memory belonging to the cancel_token.

The fix on the caller side is:

```rust
        let mut ictx = {
            let cancel_token = self.cancel_token.clone();
            ffmpeg_utils::input_with_interrupt_and_dictionary(
                Path::new(&self.stream_config.url),
                // Clone and move the cancel_token
                move || {
                    if cancel_token.is_cancelled() {
                        info!("Cancellation requested, stopping read");
                        return true; // Return 1 to indicate interruption
                    }
                    false // Return 0 to continue reading
                },
                opts,
            )?
        };
```

And the way to enforce this is to add the `'static` bound.