### PR TITLE
frame: expose AVFrame.decode_error_flags

### DIFF
--- a/src/util/frame/decode_error.rs
+++ b/src/util/frame/decode_error.rs
@@ -1,0 +1,14 @@
+use ffi::*;
+use libc::c_int;
+
+bitflags! {
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    pub struct DecodeError: c_int {
+        const INVALID_BITSTREAM = FF_DECODE_ERROR_INVALID_BITSTREAM;
+        const MISSING_REFERENCE = FF_DECODE_ERROR_MISSING_REFERENCE;
+        #[cfg(feature = "ffmpeg_5_1")]
+        const CONCEALMENT_ACTIVE = FF_DECODE_ERROR_CONCEALMENT_ACTIVE;
+        #[cfg(feature = "ffmpeg_5_1")]
+        const DECODE_SLICES = FF_DECODE_ERROR_DECODE_SLICES;
+    }
+}

--- a/src/util/frame/mod.rs
+++ b/src/util/frame/mod.rs
@@ -10,6 +10,9 @@ pub use self::audio::Audio;
 pub mod flag;
 pub use self::flag::Flags;
 
+pub mod decode_error;
+pub use self::decode_error::DecodeError;
+
 use ffi::*;
 use {Dictionary, DictionaryRef};
 
@@ -82,6 +85,16 @@ impl Frame {
     #[inline]
     pub fn is_corrupt(&self) -> bool {
         self.flags().contains(Flags::CORRUPT)
+    }
+
+    #[inline]
+    pub fn decode_error_flags(&self) -> DecodeError {
+        unsafe { DecodeError::from_bits_truncate((*self.as_ptr()).decode_error_flags) }
+    }
+
+    #[inline]
+    pub fn has_decode_errors(&self) -> bool {
+        !self.decode_error_flags().is_empty()
     }
 
     #[inline]


### PR DESCRIPTION
Add DecodeError bitflags and Frame::decode_error_flags() / has_decode_errors(), surfacing decoder concealment (e.g. missing reference) not reflected by AV_FRAME_FLAG_CORRUPT.