### PR TITLE
feat: expose codec parameter setters

### DIFF
--- a/src/codec/parameters.rs
+++ b/src/codec/parameters.rs
@@ -45,8 +45,30 @@ impl Parameters {
         unsafe { media::Type::from((*self.as_ptr()).codec_type) }
     }
 
+    pub fn set_medium(&mut self, value: media::Type) {
+        unsafe {
+            (*self.as_mut_ptr()).codec_type = value.into();
+        }
+    }
+
     pub fn id(&self) -> Id {
         unsafe { Id::from((*self.as_ptr()).codec_id) }
+    }
+
+    pub fn set_id(&mut self, value: Id) {
+        unsafe {
+            (*self.as_mut_ptr()).codec_id = value.into();
+        }
+    }
+
+    pub fn bit_rate(&self) -> i64 {
+        unsafe { (*self.as_ptr()).bit_rate }
+    }
+
+    pub fn set_bit_rate(&mut self, value: i64) {
+        unsafe {
+            (*self.as_mut_ptr()).bit_rate = value;
+        }
     }
 }
 
@@ -89,5 +111,22 @@ impl<C: AsRef<Context>> From<C> for Parameters {
             avcodec_parameters_from_context(parameters.as_mut_ptr(), context.as_ptr());
         }
         parameters
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sets_codec_parameters() {
+        let mut parameters = Parameters::new();
+        parameters.set_medium(media::Type::Subtitle);
+        parameters.set_id(Id::WEBVTT);
+        parameters.set_bit_rate(64_000);
+
+        assert_eq!(parameters.medium(), media::Type::Subtitle);
+        assert_eq!(parameters.id(), Id::WEBVTT);
+        assert_eq!(parameters.bit_rate(), 64_000);
     }
 }


### PR DESCRIPTION
Add safe accessors for codec media type, codec id, and bitrate so callers do not need to access AVCodecParameters directly.